### PR TITLE
feat: add ebay navigation link and improve overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     .nav-toggle.open .line:nth-child(3){transform:translateY(-9px) rotate(-45deg)}
 
     /* Overlay Menu (desktop & mobile) */
-    .nav-menu{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;background:rgba(21,21,21,.95);transform:translateY(-100%);pointer-events:none;opacity:0;transition:transform .45s cubic-bezier(.34,1.56,.64,1),opacity .3s;z-index:10000}
+    .nav-menu{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;background:rgba(21,21,21,.85);backdrop-filter:blur(8px);box-shadow:0 0 0 100vmax rgba(0,0,0,.55);transform:translateY(-100%);pointer-events:none;opacity:0;transition:transform .45s cubic-bezier(.34,1.56,.64,1),opacity .3s;z-index:10000}
     .nav-menu.open{transform:translateY(0);pointer-events:auto;opacity:1}
     .nav-menu a{color:var(--white);font-size:1.8rem;font-weight:600;text-decoration:none;position:relative}
     .nav-menu a::after{content:"";position:absolute;left:0;bottom:-6px;width:0;height:2px;background:var(--orange);transition:width .3s}


### PR DESCRIPTION
## Summary
- include eBay in the overlay nav and order links to match page sections
- darken and blur overlay backdrop so it covers all navigation items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689388021d9c832ca9634fa637c978a0