### PR TITLE
fix: restore eBay link in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
     <!-- Overlay menu -->
     <nav class="nav-menu" aria-hidden="true">
       <a href="#home">Home</a>
-      <a href="https://ebay.us/m/TjPzD2" target="_blank" rel="noopener noreferrer">eBay Store</a>
+      <a href="#ebay">eBay</a>
       <a href="#offerup">OfferUp</a>
       <a href="#about">About Me</a>
       <a href="#contact">Business Inquiries</a>


### PR DESCRIPTION
## Summary
- restore eBay link in the overlay navigation menu

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ccc7da08832ca025888e822a215a