### PR TITLE
fix: restore eBay link in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
     <!-- Overlay menu -->
     <nav class="nav-menu" aria-hidden="true">
       <a href="#home">Home</a>
-      <a href="https://ebay.us/m/TjPzD2" target="_blank" rel="noopener noreferrer">eBay Store</a>
+      <a href="#ebay">eBay</a>
       <a href="#offerup">OfferUp</a>
       <a href="#about">About Me</a>
       <a href="#contact">Business Inquiries</a>
@@ -176,7 +176,7 @@
       <div class="section-content">
         <div class="card reveal">
           <h2>About HecCollects</h2>
-          <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and why they compare the way they do in their respective hobby/niche. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
+          <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and how they compare within their respective hobbies. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
         </div>
       </div>
       <span class="scroll-cue">Swipe / scroll ↓</span>


### PR DESCRIPTION
## Summary
- ensure overlay nav includes an eBay quick link
- clarify About section wording

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ccc7da08832ca025888e822a215a