### PR TITLE
Improve section centering and scroll behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,10 @@
     @keyframes bg-shift{0%,100%{background-position:0% 50%}50%{background-position:100% 50%}}
 
     /* ---------- Wrapper & Sections ---------- */
-    .wrapper{height:100vh;overflow-y:auto;scroll-snap-type:y mandatory;scroll-behavior:smooth}
+    .wrapper{height:100vh;overflow-y:auto;scroll-snap-type:y mandatory;scroll-behavior:smooth;scroll-padding-top:80px}
     section{position:relative;height:100vh;scroll-snap-align:start;display:flex;align-items:center;justify-content:center;text-align:center;background-position:center 20%;background-size:cover;background-repeat:no-repeat}
     section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z-index:0}
-    .section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:2rem;margin-top:12vh}
+    .section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem}
 
     /* ---------- Card ---------- */
     .card{background:rgba(255,255,255,.08);backdrop-filter:blur(8px);border:2px solid rgba(255,255,255,.18);border-radius:1.6rem;padding:2rem 1.4rem;width:100%;max-width:460px;box-shadow:0 25px 50px rgba(0,0,0,.35);transition:transform .45s cubic-bezier(.34,1.56,.64,1);display:flex;flex-direction:column;align-items:center;gap:1.4rem}


### PR DESCRIPTION
## Summary
- ensure section cards stay centered by removing extra top offset
- offset scroll target to account for fixed header
- stop prior section's background from peeking in while scrolling by using scroll-padding on wrapper

## Testing
- `npx --yes htmlhint index.html`
- `curl -I https://ebay.us/m/TjPzD2` *(403 Forbidden)*
- `curl -I https://offerup.co/3D5QQbGZyVb` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894130a6718832c9664ea5248155de5