### PR TITLE
Add Playwright navigation scroll test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "heccollects.github.io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "heccollects.github.io",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "heccollects.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.54.2"
+  }
+}

--- a/tests/scroll.spec.ts
+++ b/tests/scroll.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+const navTargets = ['#home', '#ebay', '#offerup', '#about', '#contact'];
+
+test('navigation links scroll to correct sections', async ({ page }) => {
+  await page.goto('file://' + filePath);
+
+  for (const target of navTargets) {
+    await page.click('.nav-toggle');
+    await page.locator('.nav-menu.open').waitFor();
+    await page.evaluate((selector) => {
+      (document.querySelector(`.nav-menu a[href="${selector}"]`) as HTMLElement).click();
+    }, target);
+    await page.waitForTimeout(1000);
+
+    const { scrollY, offsetTop } = await page.evaluate((selector) => {
+      const el = document.querySelector(selector)! as HTMLElement;
+      return { scrollY: window.scrollY, offsetTop: el.offsetTop };
+    }, target);
+
+    const diff = Math.abs(scrollY - offsetTop);
+    expect(diff, `${target} is off by ${diff}px`).toBeLessThanOrEqual(1);
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright scroll-position test clicking each navigation link and asserting window.scrollY matches section offset
- configure npm with Playwright test dependency and script

## Testing
- `npm test` *(fails: #ebay is off by 720px)*

------
https://chatgpt.com/codex/tasks/task_e_68942eea9914832cb02cf5cd2e7de14e