### PR TITLE
Replace fixed scroll wait with position polling

### DIFF
--- a/tests/scroll.spec.ts
+++ b/tests/scroll.spec.ts
@@ -14,7 +14,10 @@ test('navigation links scroll to correct sections', async ({ page }) => {
     await page.evaluate((selector) => {
       (document.querySelector(`.nav-menu a[href="${selector}"]`) as HTMLElement).click();
     }, target);
-    await page.waitForTimeout(1000);
+    await page.waitForFunction(
+      sel => Math.abs(window.scrollY - document.querySelector(sel).offsetTop) <= 1,
+      target
+    );
 
     const { scrollY, offsetTop } = await page.evaluate((selector) => {
       const el = document.querySelector(selector)! as HTMLElement;


### PR DESCRIPTION
## Summary
- wait for navigation scroll to reach its target position instead of sleeping

## Testing
- `npm test` *(fails: page.waitForFunction timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68943a14277c832c97627f6d807eef64