### PR TITLE
Guard menu script against missing elements

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
 (() => {
   const burger = document.querySelector('.nav-toggle');
   const navMenu = document.querySelector('.nav-menu');
+
+  if (!burger || !navMenu) return;
+
   const links = Array.from(navMenu.querySelectorAll('a'));
 
   const openMenu = () => {
@@ -36,7 +39,7 @@
 
     if (e.key === 'Escape') {
       closeMenu();
-    } else if (e.key === 'Tab') {
+    } else if (e.key === 'Tab' && links.length) {
       const first = links[0];
       const last = links[links.length - 1];
 


### PR DESCRIPTION
## Summary
- prevent the menu script from running when the toggle or menu is missing
- avoid tab trapping logic when the menu has no links

## Testing
- `npx playwright install chromium firefox webkit` *(fails: Download failed: server returned code 403)*
- `npm test` *(fails: missing system libraries; 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68944064ee34832cadc610334c861f74