### PR TITLE
Center ripple on keyboard activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,15 +209,30 @@
   <script>
     // Ripple
     document.querySelectorAll('.btn').forEach(btn => {
-      btn.addEventListener('click', e => {
-        const circle  = document.createElement('span');
-        const size    = Math.max(btn.clientWidth, btn.clientHeight);
+      const showRipple = (x, y) => {
+        const circle = document.createElement('span');
+        const size = Math.max(btn.clientWidth, btn.clientHeight);
         circle.style.width = circle.style.height = `${size}px`;
-        circle.style.left  = `${e.clientX - btn.getBoundingClientRect().left - size/2}px`;
-        circle.style.top   = `${e.clientY - btn.getBoundingClientRect().top  - size/2}px`;
+        circle.style.left = `${x - size / 2}px`;
+        circle.style.top = `${y - size / 2}px`;
         circle.classList.add('ripple');
         btn.appendChild(circle);
         setTimeout(() => circle.remove(), 600);
+      };
+
+      btn.addEventListener('click', e => {
+        const rect = btn.getBoundingClientRect();
+        const hasCoords = typeof e.clientX === 'number' && typeof e.clientY === 'number' && (e.clientX !== 0 || e.clientY !== 0);
+        const x = hasCoords ? e.clientX - rect.left : rect.width / 2;
+        const y = hasCoords ? e.clientY - rect.top : rect.height / 2;
+        showRipple(x, y);
+      });
+
+      btn.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          btn.click();
+        }
       });
     });
 


### PR DESCRIPTION
## Summary
- Center the ripple animation when click events lack coordinates, such as keyboard-triggered activations
- Add keydown handling for Enter/Space to trigger centered ripples

## Testing
- `npx playwright install` *(fails: Failed to download Webkit 26.0 due to 403 Forbidden)*
- `npx playwright test --project=chromium --project=firefox` *(fails: missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6894b39b04e0832cab7b8f51a0359356