### PR TITLE
Add null check for missing preloader

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,8 +224,10 @@
     // Preloader
     window.addEventListener('load', () => {
       const pre = document.getElementById('preloader');
-      pre.classList.add('hide');
-      setTimeout(() => pre.remove(), 600);
+      if (pre) {
+        pre.classList.add('hide');
+        setTimeout(() => pre.remove(), 600);
+      }
     });
 
     // Reveal on scroll


### PR DESCRIPTION
## Summary
- avoid runtime errors when `#preloader` is not present by guarding its manipulation with a null check

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6894b39b8bf4832cb75d254481009d51