### PR TITLE
Refactor nav menu placement and layering

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     .nav-toggle.open .line:nth-child(3){transform:translateY(-9px) rotate(-45deg)}
 
     /* Overlay Menu (desktop & mobile) */
-    .nav-menu{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;background:rgba(21,21,21,.85);backdrop-filter:blur(8px);box-shadow:0 0 0 100vmax rgba(0,0,0,.55);transform:translateY(-100%);pointer-events:none;opacity:0;transition:transform .45s cubic-bezier(.34,1.56,.64,1),opacity .3s;z-index:10000}
+    .nav-menu{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;background:rgba(21,21,21,.85);backdrop-filter:blur(8px);box-shadow:0 0 0 100vmax rgba(0,0,0,.55);transform:translateY(-100%);pointer-events:none;opacity:0;transition:transform .45s cubic-bezier(.34,1.56,.64,1),opacity .3s;z-index:10001}
     .nav-menu.open{transform:translateY(0);pointer-events:auto;opacity:1}
     .nav-menu a{color:var(--white);font-size:1.8rem;font-weight:600;text-decoration:none;position:relative}
     .nav-menu a::after{content:"";position:absolute;left:0;bottom:-6px;width:0;height:2px;background:var(--orange);transition:width .3s}
@@ -122,16 +122,16 @@
       <span class="line"></span>
       <span class="line"></span>
     </button>
-
-    <!-- Overlay menu -->
-    <nav class="nav-menu" aria-hidden="true">
-      <a href="#home">Home</a>
-      <a href="#ebay">eBay</a>
-      <a href="#offerup">OfferUp</a>
-      <a href="#about">About Me</a>
-      <a href="#contact">Business Inquiries</a>
-    </nav>
   </header>
+
+  <!-- Overlay menu -->
+  <nav id="nav-menu" class="nav-menu" aria-hidden="true">
+    <a href="#home">Home</a>
+    <a href="#ebay">eBay</a>
+    <a href="#offerup">OfferUp</a>
+    <a href="#about">About Me</a>
+    <a href="#contact">Business Inquiries</a>
+  </nav>
 
   <!-- Sections -->
   <main>


### PR DESCRIPTION
## Summary
- Move overlay navigation menu outside header and give it an id for scripting
- Raise menu z-index so fixed overlay sits above all content
- Keep header’s blur effect via backdrop-filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894cd1975ac832cbb58d7a92bd04744