### PR TITLE
Add honeypot and captcha to subscribe form

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,10 @@
           <p>Join the mailing list for new drops and exclusive deals.</p>
           <form action="https://formspree.io/f/mzzdeork" method="POST" class="subscribe-form">
             <input type="email" name="email" placeholder="Email address" required>
+            <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
+            <div class="h-captcha" data-sitekey="10000000-ffff-ffff-ffff-000000000001"></div>
             <button type="submit" class="btn">Subscribe</button>
+            <p id="subscribe-msg" class="form-msg" aria-live="polite"></p>
           </form>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,12 @@
 (() => {
+  if(location.protocol !== 'file:'){
+    const s = document.createElement('script');
+    s.src = 'https://hcaptcha.com/1/api.js';
+    s.async = true;
+    s.defer = true;
+    document.head.appendChild(s);
+  }
+
   const burger = document.querySelector('.nav-toggle');
   const navMenu = document.getElementById('nav-menu');
 
@@ -155,6 +163,44 @@
     });
     heroCard.addEventListener('mouseleave', () => {
       heroCard.style.transform = '';
+    });
+  }
+
+  // Subscribe form handling with honeypot and hCaptcha
+  const subscribeForm = document.querySelector('.subscribe-form');
+  if(subscribeForm){
+    const msg = document.getElementById('subscribe-msg');
+    subscribeForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      msg.textContent = '';
+      const hp = subscribeForm.querySelector('input[name="hp"]');
+      if(hp && hp.value){
+        msg.textContent = 'Submission rejected.';
+        return;
+      }
+      const token = window.hcaptcha?.getResponse();
+      if(!token){
+        msg.textContent = 'Please complete the captcha.';
+        return;
+      }
+      try{
+        const formData = new FormData(subscribeForm);
+        formData.append('h-captcha-response', token);
+        const res = await fetch(subscribeForm.action, {
+          method:'POST',
+          body:formData,
+          headers:{Accept:'application/json'}
+        });
+        if(res.ok){
+          msg.textContent = 'Thanks for subscribing!';
+          subscribeForm.reset();
+          window.hcaptcha?.reset();
+        }else{
+          msg.textContent = 'Submission failed. Please try again later.';
+        }
+      }catch{
+        msg.textContent = 'Submission failed. Please try again later.';
+      }
     });
   }
 })();

--- a/style.css
+++ b/style.css
@@ -43,6 +43,8 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .subscribe-form{display:flex;flex-direction:column;gap:.7rem;width:100%}
 .subscribe-form input{padding:.8rem 1rem;border-radius:.8rem;border:none;font-size:1rem}
 .subscribe-form button{align-self:flex-end}
+.honeypot{display:none}
+.form-msg{font-size:.9rem;color:var(--orange)}
 /* Ripple */
 .ripple{position:absolute;border-radius:50%;transform:scale(0);background:rgba(255,255,255,.35);animation:ripple .6s linear}
 @keyframes ripple{to{transform:scale(4);opacity:0}}


### PR DESCRIPTION
## Summary
- add hidden honeypot field with hCaptcha widget on subscribe form
- dynamically load hCaptcha and validate form before posting to Formspree
- hide honeypot field and show submission feedback messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896bb599770832ca75afeb472a097e1