### PR TITLE
Add Playwright test for preloader and ripple cleanup

### DIFF
--- a/tests/preloader-ripple.spec.ts
+++ b/tests/preloader-ripple.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+test('preloader is removed and ripple cleans up', async ({ page }) => {
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      throw new Error(msg.text());
+    }
+  });
+
+  await page.goto('file://' + filePath);
+  await page.waitForLoadState('load');
+
+  await page.waitForSelector('#preloader', { state: 'detached' });
+  await expect(page.locator('#preloader')).toHaveCount(0);
+
+  const btn = page.locator('.btn').first();
+  await btn.click();
+
+  const ripple = btn.locator('.ripple');
+  await expect(ripple).toHaveCount(1);
+  const start = Date.now();
+  await expect(ripple).toHaveCount(0);
+  const elapsed = Date.now() - start;
+  expect(elapsed).toBeLessThan(1000);
+});


### PR DESCRIPTION
## Summary
- add Playwright test ensuring preloader is removed after window load
- verify ripple effect appears and disappears within expected time
- check page emits no console errors across browsers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896bb5f2c84832cbd2abdb39e51abe1