### PR TITLE
Improve desktop layout and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,24 +19,21 @@
   <!-- Navbar -->
   <header class="navbar">
     <div class="brand">HecCollects</div>
-
+    <nav id="nav-menu" class="nav-menu" aria-hidden="true">
+      <a href="#home">Home</a>
+      <a href="#ebay">eBay</a>
+      <a href="#offerup">OfferUp</a>
+      <a href="#about">About Me</a>
+      <a href="#testimonials">Testimonials</a>
+      <a href="#subscribe">Subscribe</a>
+      <a href="#contact">Business Inquiries</a>
+    </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line"></span>
       <span class="line"></span>
       <span class="line"></span>
     </button>
   </header>
-
-  <!-- Overlay menu -->
-  <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-    <a href="#home">Home</a>
-    <a href="#ebay">eBay</a>
-    <a href="#offerup">OfferUp</a>
-    <a href="#about">About Me</a>
-    <a href="#testimonials">Testimonials</a>
-    <a href="#subscribe">Subscribe</a>
-    <a href="#contact">Business Inquiries</a>
-  </nav>
 
   <!-- Sections -->
   <main>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@
   if (!burger || !navMenu) return;
 
   const links = Array.from(navMenu.querySelectorAll('a'));
+  const mql = window.matchMedia('(min-width: 1024px)');
 
   const openMenu = () => {
     burger.classList.add('open');
@@ -23,6 +24,7 @@
   };
 
   const closeMenu = (focusBurger = true) => {
+    if (mql.matches) return;
     burger.classList.remove('open');
     navMenu.classList.remove('open');
     burger.setAttribute('aria-expanded', 'false');
@@ -43,7 +45,7 @@
   });
 
   document.addEventListener('keydown', (e) => {
-    if (!navMenu.classList.contains('open')) return;
+    if (!navMenu.classList.contains('open') || mql.matches) return;
 
     if (e.key === 'Escape') {
       closeMenu();
@@ -60,6 +62,24 @@
       }
     }
   });
+
+  const handleBreakpoint = (e) => {
+    if (e.matches) {
+      navMenu.classList.add('open');
+      navMenu.setAttribute('aria-hidden', 'false');
+      burger.style.display = 'none';
+      burger.setAttribute('aria-hidden', 'true');
+      burger.tabIndex = -1;
+    } else {
+      navMenu.classList.remove('open');
+      navMenu.setAttribute('aria-hidden', 'true');
+      burger.style.display = '';
+      burger.setAttribute('aria-hidden', 'false');
+      burger.tabIndex = 0;
+    }
+  };
+  handleBreakpoint(mql);
+  mql.addEventListener('change', handleBreakpoint);
 
   // Outbound click tracking
   const trackables = document.querySelectorAll('[data-analytics]');

--- a/style.css
+++ b/style.css
@@ -77,6 +77,15 @@ h2{font-size:1.65rem}
 @media(min-width:641px){
 section{background-attachment:fixed}
 }
+@media(min-width:1024px){
+  .nav-toggle{display:none}
+  .nav-menu{position:static;transform:none;opacity:1;pointer-events:auto;flex-direction:row;gap:2rem;background:none;backdrop-filter:none;box-shadow:none;height:auto}
+  .nav-menu a{font-size:1rem}
+  .card{max-width:900px;padding:3rem 4rem}
+  .featured-items{flex-wrap:wrap;overflow:visible;gap:1rem}
+  .featured-items a{flex:0 1 calc(33% - 1rem);scroll-snap-align:none}
+  .featured-items img{height:200px}
+}
 /* ---------- Background Images ---------- */
 #home,#ebay,#offerup,#about,#contact{background-image:none}
 #preloader{position:fixed;inset:0;background:var(--black);display:flex;align-items:center;justify-content:center;z-index:100000;transition:opacity .6s}

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
 
+test.use({ viewport: { width: 375, height: 667 } });
+
 const filePath = path.resolve(__dirname, '../index.html');
 
 test('menu supports keyboard navigation', async ({ page }) => {

--- a/tests/scroll.spec.ts
+++ b/tests/scroll.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
 
+test.use({ viewport: { width: 375, height: 667 } });
+
 const filePath = path.resolve(__dirname, '../index.html');
 
 const navTargets = ['#home', '#ebay', '#offerup', '#about', '#testimonials', '#subscribe', '#contact'];


### PR DESCRIPTION
## Summary
- Move navigation menu into the header and display links inline on desktop
- Add desktop-specific styling for wider cards and grid-style featured items
- Adjust navigation script and tests for responsive desktop/mobile behavior

## Testing
- `npx playwright install`
- `npx playwright install-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897620516a4832c8b562e6b52b3fcb1