### PR TITLE
Add real eBay and OfferUp featured items with responsive hover effects

### DIFF
--- a/items.json
+++ b/items.json
@@ -1,36 +1,16 @@
 {
   "ebay": [
     {
-      "image": "https://images.unsplash.com/photo-1606813902777-c5a64d40d7f8?auto=format&fit=crop&w=300&h=300",
-      "link": "https://ebay.us/m/TjPzD2",
-      "alt": "Assorted trading cards in sleeves"
-    },
-    {
-      "image": "https://images.unsplash.com/photo-1581291518857-4e27b48ff24e?auto=format&fit=crop&w=300&h=300",
-      "link": "https://ebay.us/m/TjPzD2",
-      "alt": "Vintage action figure on display"
-    },
-    {
-      "image": "https://images.unsplash.com/photo-1583511655826-057b20021a10?auto=format&fit=crop&w=300&h=300",
-      "link": "https://ebay.us/m/TjPzD2",
-      "alt": "Retro video game controller"
+      "image": "https://i.ebayimg.com/images/g/PJkAAeSwqElomAoX/s-l400.jpg",
+      "link": "https://www.ebay.com/itm/376470198032",
+      "alt": "Featured eBay collectible"
     }
   ],
   "offerup": [
     {
-      "image": "https://images.unsplash.com/photo-1606819726060-59b7f06f25a1?auto=format&fit=crop&w=300&h=300",
+      "image": "https://images.offerup.com/gibOyZLRsEMaDznSr5iwK3UpCMc=/800x800/smart/7542/75424d3ed81d46228f0dde5a7c77cf02.jpg",
       "link": "https://offerup.co/3D5QQbGZyVb",
-      "alt": "Stack of classic comic books"
-    },
-    {
-      "image": "https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=300&h=300",
-      "link": "https://offerup.co/3D5QQbGZyVb",
-      "alt": "Polaroid camera with film"
-    },
-    {
-      "image": "https://images.unsplash.com/photo-1599507593362-650bdc06e1af?auto=format&fit=crop&w=300&h=300",
-      "link": "https://offerup.co/3D5QQbGZyVb",
-      "alt": "Toy collectible car"
+      "alt": "Featured OfferUp item"
     }
   ]
 }

--- a/style.css
+++ b/style.css
@@ -31,10 +31,11 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 /* Featured listings */
 .featured{margin-top:1rem;width:100%;text-align:left}
 .featured h3{margin-bottom:.5rem;font-size:1.2rem;color:var(--orange)}
-.featured-items{display:flex;gap:1rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;-ms-overflow-style:none;scrollbar-width:none}
+.featured-items{display:flex;gap:1rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;-ms-overflow-style:none;scrollbar-width:none;justify-content:center}
 .featured-items::-webkit-scrollbar{display:none}
-.featured-items a{display:flex;flex-direction:column;align-items:center;text-decoration:none;color:var(--white);flex:0 0 80%;scroll-snap-align:center}
-.featured-items img{width:100%;height:150px;object-fit:cover;border-radius:.6rem;margin-bottom:.25rem}
+.featured-items a{display:flex;flex-direction:column;align-items:center;text-decoration:none;color:var(--white);flex:0 0 80%;scroll-snap-align:center;overflow:hidden;border-radius:.6rem}
+.featured-items img{width:100%;height:150px;object-fit:cover;border-radius:.6rem;margin-bottom:.25rem;transition:transform .3s,box-shadow .3s}
+.featured-items a:hover img{transform:scale(1.08);box-shadow:0 8px 16px rgba(0,0,0,.4)}
 .promo{margin-top:.8rem;font-size:.9rem;color:var(--orange)}
 /* Testimonials */
 .testimonials figure{margin-bottom:1.2rem}
@@ -82,9 +83,9 @@ section{background-attachment:fixed}
   .nav-menu{position:static;transform:none;opacity:1;pointer-events:auto;flex-direction:row;gap:2rem;background:none;backdrop-filter:none;box-shadow:none;height:auto}
   .nav-menu a{font-size:1rem}
   .card{max-width:900px;padding:3rem 4rem}
-  .featured-items{flex-wrap:wrap;overflow:visible;gap:1rem}
+  .featured-items{flex-wrap:wrap;overflow:visible;gap:1rem;justify-content:center}
   .featured-items a{flex:0 1 calc(33% - 1rem);scroll-snap-align:none}
-  .featured-items img{height:200px}
+  .featured-items img{height:200px;transition:transform .3s,box-shadow .3s}
 }
 /* ---------- Background Images ---------- */
 #home,#ebay,#offerup,#about,#contact{background-image:none}


### PR DESCRIPTION
## Summary
- Replace placeholder featured listings with actual eBay and OfferUp items
- Center featured galleries and add hover zoom/box-shadow to attract clicks

## Testing
- `npm test` *(fails: 33 failing tests, Playwright binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_689818b0c0b4832c92ab6ddbd806af50