### PR TITLE
Fix malformed items data and remove duplicate OfferUp link

### DIFF
--- a/items.json
+++ b/items.json
@@ -1,20 +1,15 @@
 {
   "ebay": [
     {
- < wkxbwl-codex/update-featured-items-and-check-urls
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
-
- main
       "link": "https://www.ebay.com/itm/376470178564",
       "alt": "Featured eBay collectible"
     }
   ],
   "offerup": [
     {
-< wkxbwl-codex/update-featured-items-and-check-urls
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
- main
-      "link": "https://offerup.co/xluJorjDIVb",
+      "link": "https://offerup.com/item/detail/6ce9a7b2-fd73-3b66-a474-8c93c37a87e0",
       "alt": "Featured OfferUp item"
     }
   ]


### PR DESCRIPTION
## Summary
- clean up `items.json` by removing merge artifacts
- replace duplicate OfferUp store link with direct listing URL

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68989d81b3f0832c94f28db9a9696a64