### PR TITLE
Add extra featured listings to items.json

### DIFF
--- a/items.json
+++ b/items.json
@@ -4,6 +4,16 @@
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://www.ebay.com/itm/376470178564",
       "alt": "Featured eBay collectible"
+    },
+    {
+      "image": "https://placehold.co/750x750?text=eBay+Item+2",
+      "link": "https://www.ebay.com/itm/1234567890",
+      "alt": "Featured eBay collectible 2"
+    },
+    {
+      "image": "https://placehold.co/750x750?text=eBay+Item+3",
+      "link": "https://www.ebay.com/itm/0987654321",
+      "alt": "Featured eBay collectible 3"
     }
   ],
   "offerup": [
@@ -11,6 +21,16 @@
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://offerup.co/44T5cRnMIVb",
       "alt": "Featured OfferUp item"
+    },
+    {
+      "image": "https://placehold.co/750x750?text=OfferUp+Item+2",
+      "link": "https://offerup.co/abc123",
+      "alt": "Featured OfferUp item 2"
+    },
+    {
+      "image": "https://placehold.co/750x750?text=OfferUp+Item+3",
+      "link": "https://offerup.co/def456",
+      "alt": "Featured OfferUp item 3"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- append two more eBay listings to items.json
- append two more OfferUp listings to items.json

## Testing
- `node - <<'NODE'
const { chromium } = require('playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  await page.goto('http://localhost:8000');
  const ebayCount = await page.$$eval('#ebay-items a', els => els.length);
  const offerupCount = await page.$$eval('#offerup-items a', els => els.length);
  console.log('ebay-count:', ebayCount);
  console.log('offerup-count:', offerupCount);
  await browser.close();
})();
NODE`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b83deda0832c855eeea65cb577d0