### PR TITLE
Improve featured item carousel responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,10 +31,10 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 /* Featured listings */
 .featured{margin-top:1rem;width:100%;text-align:left}
 .featured h3{margin-bottom:.5rem;font-size:1.2rem;color:var(--orange)}
-.featured-items{display:flex;gap:1rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;-ms-overflow-style:none;scrollbar-width:none;justify-content:center}
+.featured-items{display:flex;gap:1rem;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;-ms-overflow-style:none;scrollbar-width:none;justify-content:center;scroll-padding-inline:1rem}
 .featured-items::-webkit-scrollbar{display:none}
-.featured-items a{display:flex;flex-direction:column;align-items:center;text-decoration:none;color:var(--white);flex:0 0 250px;scroll-snap-align:center;overflow:hidden;border-radius:.6rem}
-.featured-items img{width:100%;height:150px;object-fit:cover;border-radius:.6rem;margin-bottom:.25rem;transition:transform .3s,box-shadow .3s}
+.featured-items a{display:flex;flex-direction:column;align-items:center;text-decoration:none;color:var(--white);flex:0 0 80%;scroll-snap-align:start;overflow:hidden;border-radius:.6rem}
+.featured-items img{width:100%;aspect-ratio:16/9;height:auto;object-fit:contain;border-radius:.6rem;margin-bottom:.25rem;transition:transform .3s,box-shadow .3s}
 .featured-items a:hover img{transform:scale(1.08);box-shadow:0 8px 16px rgba(0,0,0,.4)}
 .promo{margin-top:.8rem;font-size:.9rem;color:var(--orange)}
 /* Testimonials */
@@ -84,7 +84,7 @@ section{background-attachment:fixed}
   .nav-menu a{font-size:1rem}
   .card{max-width:900px;padding:3rem 4rem}
   .featured-items{gap:1rem;justify-content:center}
-  .featured-items img{height:200px;transition:transform .3s,box-shadow .3s}
+  .featured-items a{flex:0 0 250px}
 }
 /* ---------- Background Images ---------- */
 #home,#ebay,#offerup,#about,#contact{background-image:none}


### PR DESCRIPTION
## Summary
- make featured item carousel items use 80% flex-basis with scroll snapping to start and add scroll padding
- use aspect ratio and object-fit:contain for featured images
- restore fixed 250px width on desktop

## Testing
- `npx playwright screenshot index.html desktop.png`
- `npx playwright screenshot --device "iPhone 11" index.html mobile.png`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c4651ec8832ca1b8451ead642b45