### PR TITLE
Replace hCaptcha with Cloudflare Turnstile

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://hcaptcha.com https://*.hcaptcha.com; img-src 'self' https://www.marchingdogs.com" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com; img-src 'self' https://www.marchingdogs.com" />
   <title>HecCollects – Landing Page</title>
 
   <!-- Fonts and icons removed for offline testing -->
@@ -130,7 +130,7 @@
           <form action="https://formspree.io/f/mzzdeork" method="POST" class="subscribe-form">
             <input type="email" name="email" placeholder="Email address" required>
             <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
-            <div class="h-captcha" data-sitekey="10000000-ffff-ffff-ffff-000000000001" data-callback="enableSubscribe" data-expired-callback="disableSubscribe" data-error-callback="disableSubscribe"></div>
+              <div class="cf-turnstile" data-sitekey="YOUR_TURNSTILE_SITE_KEY" data-callback="enableSubscribe"></div>
             <button type="submit" class="btn" disabled>Subscribe</button>
             <p id="subscribe-msg" class="form-msg" aria-live="polite"></p>
           </form>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 (() => {
   if(location.protocol !== 'file:'){
     const s = document.createElement('script');
-    s.src = 'https://hcaptcha.com/1/api.js';
+    s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
     s.async = true;
     s.defer = true;
     document.head.appendChild(s);
@@ -213,7 +213,7 @@
     });
   }
 
-  // Subscribe form handling with honeypot and hCaptcha
+  // Subscribe form handling with honeypot and Turnstile
   const subscribeForm = document.querySelector('.subscribe-form');
   if(subscribeForm){
     const msg = document.getElementById('subscribe-msg');
@@ -230,14 +230,14 @@
         msg.textContent = 'Submission rejected.';
         return;
       }
-      const token = window.hcaptcha?.getResponse();
+      const token = window.turnstile?.getResponse();
       if(!token){
         msg.textContent = 'Please complete the captcha.';
         return;
       }
       try{
         const formData = new FormData(subscribeForm);
-        formData.append('h-captcha-response', token);
+        formData.append('cf-turnstile-response', token);
         const res = await fetch(subscribeForm.action, {
           method:'POST',
           body:formData,
@@ -247,7 +247,7 @@
           msg.textContent = 'Thanks for subscribing!';
           subscribeForm.reset();
           disableBtn();
-          window.hcaptcha?.reset();
+          window.turnstile?.reset();
         }else{
           msg.textContent = 'Submission failed. Please try again later.';
         }

--- a/style.css
+++ b/style.css
@@ -46,6 +46,7 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .subscribe-form{display:flex;flex-direction:column;gap:.7rem;width:100%}
 .subscribe-form input{padding:.8rem 1rem;border-radius:.8rem;border:none;font-size:1rem}
 .subscribe-form button{align-self:flex-end}
+.cf-turnstile{align-self:center}
 .honeypot{display:none}
 .form-msg{font-size:.9rem;color:var(--orange)}
 /* Ripple */


### PR DESCRIPTION
## Summary
- swap hCaptcha widget for Cloudflare Turnstile and update CSP
- load Turnstile API and send cf-turnstile-response token in subscribe handler
- style and center Turnstile widget in subscribe form

## Testing
- `npx playwright install-deps`
- `npx playwright install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d04d6b18832c990b9b1b7c12fd06