### PR TITLE
Allow Turnstile iframe through CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com; img-src 'self' https://www.marchingdogs.com" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com; img-src 'self' https://www.marchingdogs.com; frame-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'" />
   <title>HecCollects – Landing Page</title>
 
   <!-- Fonts and icons removed for offline testing -->


### PR DESCRIPTION
## Summary
- allow Cloudflare Turnstile iframe by permitting `https://challenges.cloudflare.com` in `frame-src`
- enable inline styles via CSP `style-src 'self' 'unsafe-inline'`

## Testing
- `npm test` *(fails: preloader is removed and ripple cleans up)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5c30f58832c8d8228017d53d26d