### PR TITLE
Load Turnstile when served locally

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,9 @@
 (() => {
-  if(location.protocol !== 'file:'){
-    const s = document.createElement('script');
-    s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
-    s.async = true;
-    s.defer = true;
-    document.head.appendChild(s);
-  }
+  const s = document.createElement('script');
+  s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+  s.async = true;
+  s.defer = true;
+  document.head.appendChild(s);
 
   const burger = document.querySelector('.nav-toggle');
   const navMenu = document.getElementById('nav-menu');


### PR DESCRIPTION
## Summary
- always inject Cloudflare Turnstile script regardless of protocol so it loads during local file testing

## Testing
- `npm test` (fails: 36 failed)


------
https://chatgpt.com/codex/tasks/task_e_6898d5c4350c832ca583c30f46cc831e