### PR TITLE
Replace Cloudflare Turnstile test key

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
           <form action="https://formspree.io/f/mzzdeork" method="POST" class="subscribe-form">
             <input type="email" name="email" placeholder="Email address" required>
             <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
-              <div class="cf-turnstile" data-sitekey="YOUR_TURNSTILE_SITE_KEY" data-callback="enableSubscribe"></div>
+              <div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-callback="enableSubscribe"></div>
             <button type="submit" class="btn" disabled>Subscribe</button>
             <p id="subscribe-msg" class="form-msg" aria-live="polite"></p>
           </form>


### PR DESCRIPTION
## Summary
- replace placeholder Turnstile site key with Cloudflare's test key so the subscribe widget can render

## Testing
- `npm test`
- `npx -y http-server -p 8000` and headless browser check for hidden Turnstile token and enabled Subscribe button


------
https://chatgpt.com/codex/tasks/task_e_6898dcb1b0f8832c9363631f74874c7c