### PR TITLE
Add Open Graph and Twitter metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com; img-src 'self' https://www.marchingdogs.com; frame-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'" />
+  <meta property="og:title" content="HecCollects – Landing Page" />
+  <meta property="og:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
+  <meta property="og:url" content="https://heccollects.github.io/" />
+  <meta property="og:image" content="https://heccollects.github.io/logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="HecCollects – Landing Page" />
+  <meta name="twitter:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
+  <meta name="twitter:url" content="https://heccollects.github.io/" />
+  <meta name="twitter:image" content="https://heccollects.github.io/logo.png" />
   <title>HecCollects – Landing Page</title>
 
   <!-- Fonts and icons removed for offline testing -->


### PR DESCRIPTION
## Summary
- add Open Graph tags for title, description, URL, and preview image
- add matching Twitter card metadata for improved link previews

## Testing
- `npm test` *(fails: 36 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6898ee7318a8832c95c58e74075758e3