### PR TITLE
Add testimonial carousel with navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,19 +103,26 @@
         <div class="card reveal">
           <h2>Testimonials</h2>
           <p>What collectors and clients are saying:</p>
-          <div class="testimonials">
-            <figure>
-              <blockquote>“Hector was extremely responsive and the item arrived exactly as described.”</blockquote>
-              <figcaption>&mdash; Jordan M., Chicago, IL</figcaption>
-            </figure>
-            <figure>
-              <blockquote>“The packaging was meticulous and shipping was lightning fast. Professional service all around.”</blockquote>
-              <figcaption>&mdash; Naomi D., San Francisco, CA</figcaption>
-            </figure>
-            <figure>
-              <blockquote>“Seamless transaction from start to finish. I'll definitely be a returning customer.”</blockquote>
-              <figcaption>&mdash; Carlos R., Seattle, WA</figcaption>
-            </figure>
+          <div class="testimonials" aria-live="polite">
+            <div class="testimonial-track">
+              <figure id="testimonial-1">
+                <blockquote>“Hector was extremely responsive and the item arrived exactly as described.”</blockquote>
+                <figcaption>&mdash; Jordan M., Chicago, IL</figcaption>
+              </figure>
+              <figure id="testimonial-2">
+                <blockquote>“The packaging was meticulous and shipping was lightning fast. Professional service all around.”</blockquote>
+                <figcaption>&mdash; Naomi D., San Francisco, CA</figcaption>
+              </figure>
+              <figure id="testimonial-3">
+                <blockquote>“Seamless transaction from start to finish. I'll definitely be a returning customer.”</blockquote>
+                <figcaption>&mdash; Carlos R., Seattle, WA</figcaption>
+              </figure>
+            </div>
+            <div class="testimonial-controls">
+              <button class="testimonial-prev" aria-label="Previous testimonial">&#10094;</button>
+              <button class="testimonial-next" aria-label="Next testimonial">&#10095;</button>
+            </div>
+            <div class="testimonial-pagination" role="tablist"></div>
           </div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -197,6 +197,67 @@
       .catch(() => {});
   }
 
+  // Testimonials slider
+  const testimonialWrapper = document.querySelector('.testimonials');
+  if (testimonialWrapper) {
+    const track = testimonialWrapper.querySelector('.testimonial-track');
+    const slides = Array.from(track.querySelectorAll('figure'));
+    const prevBtn = testimonialWrapper.querySelector('.testimonial-prev');
+    const nextBtn = testimonialWrapper.querySelector('.testimonial-next');
+    const pagination = testimonialWrapper.querySelector('.testimonial-pagination');
+    let index = 0;
+    let timer;
+
+    const select = (i) => {
+      index = (i + slides.length) % slides.length;
+      track.style.transform = `translateX(-${index * 100}%)`;
+      slides.forEach((s, idx) => {
+        s.classList.toggle('active', idx === index);
+      });
+      pagination?.querySelectorAll('button').forEach((dot, idx) => {
+        dot.setAttribute('aria-selected', idx === index ? 'true' : 'false');
+      });
+    };
+
+    const start = () => {
+      timer = setInterval(() => {
+        select(index + 1);
+      }, 5000);
+    };
+
+    const reset = () => {
+      clearInterval(timer);
+      start();
+    };
+
+    slides.forEach((slide, i) => {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'testimonial-dot';
+      dot.setAttribute('role', 'tab');
+      if (slide.id) dot.setAttribute('aria-controls', slide.id);
+      dot.setAttribute('aria-label', `Show testimonial ${i + 1}`);
+      dot.addEventListener('click', () => {
+        select(i);
+        reset();
+      });
+      pagination?.appendChild(dot);
+    });
+
+    prevBtn?.addEventListener('click', () => {
+      select(index - 1);
+      reset();
+    });
+
+    nextBtn?.addEventListener('click', () => {
+      select(index + 1);
+      reset();
+    });
+
+    select(0);
+    start();
+  }
+
   // 3D tilt on hero card
   const heroCard = document.querySelector('#home .card.tilt');
   if(heroCard){

--- a/style.css
+++ b/style.css
@@ -39,9 +39,17 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .featured-items a:hover img{transform:scale(1.08);box-shadow:0 8px 16px rgba(0,0,0,.4)}
 .promo{margin-top:.8rem;font-size:.9rem;color:var(--orange)}
 /* Testimonials */
-.testimonials figure{margin-bottom:1.2rem}
+.testimonials{position:relative;overflow:hidden}
+.testimonial-track{display:flex;transition:transform .6s ease}
+.testimonial-track figure{flex:0 0 100%;margin:0;padding-bottom:1.2rem;opacity:0;transition:opacity .6s ease}
+.testimonial-track figure.active{opacity:1}
 .testimonials blockquote{font-style:italic;margin-bottom:.4rem}
 .testimonials figcaption{font-size:.9rem;color:var(--orange)}
+.testimonial-controls{position:absolute;top:50%;left:0;width:100%;display:flex;justify-content:space-between;transform:translateY(-50%);pointer-events:none}
+.testimonial-controls button{background:rgba(0,0,0,.45);color:#fff;border:none;border-radius:50%;width:32px;height:32px;cursor:pointer;pointer-events:auto}
+.testimonial-pagination{display:flex;gap:.5rem;justify-content:center;margin-top:.8rem}
+.testimonial-pagination button{width:10px;height:10px;border-radius:50%;border:none;background:rgba(255,255,255,.4);cursor:pointer}
+.testimonial-pagination button[aria-selected="true"]{background:var(--orange)}
 /* Subscribe form */
 .subscribe-form{display:flex;flex-direction:column;gap:.7rem;width:100%}
 .subscribe-form input{padding:.8rem 1rem;border-radius:.8rem;border:none;font-size:1rem}


### PR DESCRIPTION
## Summary
- Add testimonial track container with overflow-hidden styling and navigation controls
- Rotate testimonials automatically with JS slider and pagination dots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ee6b4e44832c9a7c56b52842139f