### PR TITLE
Switch landing page CAPTCHA to Google reCAPTCHA

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com; img-src 'self' https://www.marchingdogs.com; frame-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'" />
   <meta property="og:title" content="HecCollects – Landing Page" />
   <meta property="og:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta property="og:url" content="https://heccollects.github.io/" />
@@ -22,6 +22,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="config.js"></script>
   <script src="analytics.js"></script>
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
   <div id="preloader"><div class="spinner"></div></div>
@@ -146,7 +147,7 @@
           <form action="https://formspree.io/f/mzzdeork" method="POST" class="subscribe-form">
             <input type="email" name="email" placeholder="Email address" required>
             <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
-              <div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-callback="enableSubscribe"></div>
+              <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY" data-callback="enableSubscribe"></div>
             <button type="submit" class="btn" disabled>Subscribe</button>
             <p id="subscribe-msg" class="form-msg" aria-live="polite"></p>
           </form>

--- a/main.js
+++ b/main.js
@@ -1,10 +1,4 @@
 (() => {
-  const s = document.createElement('script');
-  s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
-  s.async = true;
-  s.defer = true;
-  document.head.appendChild(s);
-
   const burger = document.querySelector('.nav-toggle');
   const navMenu = document.getElementById('nav-menu');
 
@@ -282,7 +276,7 @@
     });
   }
 
-  // Subscribe form handling with honeypot and Turnstile
+  // Subscribe form handling with honeypot and reCAPTCHA
   const subscribeForm = document.querySelector('.subscribe-form');
   if(subscribeForm){
     const msg = document.getElementById('subscribe-msg');
@@ -299,14 +293,14 @@
         msg.textContent = 'Submission rejected.';
         return;
       }
-      const token = window.turnstile?.getResponse();
+      const token = window.grecaptcha?.getResponse();
       if(!token){
         msg.textContent = 'Please complete the captcha.';
         return;
       }
       try{
         const formData = new FormData(subscribeForm);
-        formData.append('cf-turnstile-response', token);
+        formData.append('g-recaptcha-response', token);
         const res = await fetch(subscribeForm.action, {
           method:'POST',
           body:formData,
@@ -319,7 +313,7 @@
             }
             subscribeForm.reset();
             disableBtn();
-            window.turnstile?.reset();
+            window.grecaptcha?.reset();
           }else{
             msg.textContent = 'Submission failed. Please try again later.';
           }


### PR DESCRIPTION
## Summary
- Add Google domains to the CSP and load the reCAPTCHA API
- Replace Turnstile widget with reCAPTCHA markup
- Update subscribe form logic for reCAPTCHA and remove Turnstile script

## Testing
- `npm test` *(fails: browserType.launch executable doesn't exist)*
- `python3 -m http.server 8000` & `node jsdom script` (Subscribe button enabled after `enableSubscribe()` callback)


------
https://chatgpt.com/codex/tasks/task_e_6898f1186978832cb34087e58ab24f51