### PR TITLE
Indicate single-quantity stock for all featured items

### DIFF
--- a/items.json
+++ b/items.json
@@ -4,21 +4,21 @@
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://www.ebay.com/itm/376470178564",
       "alt": "Featured eBay collectible",
-      "badge": "New Arrival",
-      "stock": 5
+      "badge": "Only 1 left",
+      "stock": 1
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://ebay.us/m/vs5p1e",
       "alt": "Featured eBay collectible 2",
-      "badge": "Limited Stock",
-      "stock": 2
+      "badge": "Only 1 left",
+      "stock": 1
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
       "link": "https://ebay.us/m/VTMaDx",
       "alt": "Featured eBay collectible 3",
-      "badge": "Last One",
+      "badge": "Only 1 left",
       "stock": 1
     }
   ],
@@ -27,22 +27,22 @@
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://offerup.co/44T5cRnMIVb",
       "alt": "Featured OfferUp item",
-      "badge": "Fresh Listing",
-      "stock": 4
+      "badge": "Only 1 left",
+      "stock": 1
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://offerup.co/UR4k8b1RIVb",
       "alt": "Featured OfferUp item 2",
-      "badge": "Low Stock",
-      "stock": 2
+      "badge": "Only 1 left",
+      "stock": 1
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
       "link": "https://offerup.co/iAT3Vh4RIVb",
       "alt": "Featured OfferUp item 3",
-      "badge": "Just Added",
-      "stock": 3
+      "badge": "Only 1 left",
+      "stock": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update badges and stock counts so each featured item shows 'Only 1 left'

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68996ca637d0832c959faab31ce11ff3