### PR TITLE
Fix auto-scroll caused by carousel scrollIntoView

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,11 +188,9 @@
       let idx = 0;
       const go = (i) => {
         idx = (i + items.length) % items.length;
-        items[idx]?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest',
-          inline: 'center'
-        });
+        const item = items[idx];
+        const offset = item.offsetLeft + item.offsetWidth / 2 - track.clientWidth / 2;
+        track.scrollTo({ left: offset, behavior: 'smooth' });
       };
       prev?.addEventListener('click', () => {
         go(idx - 1);


### PR DESCRIPTION
## Summary
- Avoid using `scrollIntoView` in featured carousels to prevent page from jumping vertically
- Scroll carousels horizontally with calculated offsets using `scrollTo`

## Testing
- `npm test` *(fails: 36 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68997460ae44832cbd92b6e36b8fe70d