### PR TITLE
Add border fade effect for call-to-action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
           <h1>Welcome to HecCollects</h1>
           <p>Quality • Collectibles • Community. Scroll or use the menu to explore my marketplaces and story.</p>
           <div class="links">
-            <a href="#ebay" class="btn"><i class="fa-brands fa-ebay"></i> Browse eBay Deals</a>
+            <a href="#ebay" class="btn border-fade"><i class="fa-brands fa-ebay"></i> Browse eBay Deals</a>
           </div>
         </div>
       </div>
@@ -72,7 +72,7 @@
           <h2>Shop on eBay</h2>
           <p>Browse curated listings, graded cards, and exclusive bundles at competitive prices.</p>
           <div class="links">
-            <a href="https://ebay.us/m/HoUY1I" target="_blank" rel="noopener noreferrer" class="btn" data-analytics="ebay"><i class="fa-brands fa-ebay"></i> Visit eBay Store</a>
+            <a href="https://ebay.us/m/HoUY1I" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay"><i class="fa-brands fa-ebay"></i> Visit eBay Store</a>
           </div>
           <div class="featured">
             <h3>Featured Items</h3>
@@ -94,7 +94,7 @@
           <h2>Local Deals on OfferUp</h2>
           <p>Prefer local pickup? Check out my OfferUp inventory for quick deals and meet‑ups in SoCal.</p>
           <div class="links">
-            <a href="https://offerup.co/xluJorjDIVb" target="_blank" rel="noopener noreferrer" class="btn" data-analytics="offerup"><i class="fa-solid fa-store"></i> Visit OfferUp</a>
+            <a href="https://offerup.co/xluJorjDIVb" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup"><i class="fa-solid fa-store"></i> Visit OfferUp</a>
           </div>
           <div class="featured">
             <h3>Featured Items</h3>
@@ -175,7 +175,7 @@
             <p class="privacy">We’ll never sell your data. <a href="privacy.html" target="_blank" rel="noopener">Privacy Policy</a></p>
             <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
             <div class="g-recaptcha" data-sitekey="" data-callback="enableSubscribe"></div>
-            <button type="submit" class="btn" disabled>Subscribe</button>
+            <button type="submit" class="btn border-fade" disabled>Subscribe</button>
             <p id="subscribe-msg" class="form-msg" aria-live="polite"></p>
           </form>
         </div>
@@ -189,9 +189,9 @@
           <h2>Business Inquiries</h2>
           <p>Have a question, bulk lot, or collaboration idea? Reach out and I’ll get back within 24 hours.</p>
           <div class="links">
-            <a href="mailto:hectorsandoval1402@gmail.com" class="btn" data-analytics="email"><i class="fa-solid fa-envelope"></i> Email Me</a>
-            <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn" data-analytics="instagram"><i class="fa-brands fa-instagram"></i> Instagram</a>
-            <a id="phone-link" class="btn" data-analytics="phone"><i class="fa-solid fa-phone"></i> Call Me</a>
+            <a href="mailto:hectorsandoval1402@gmail.com" class="btn border-fade" data-analytics="email"><i class="fa-solid fa-envelope"></i> Email Me</a>
+            <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="instagram"><i class="fa-brands fa-instagram"></i> Instagram</a>
+            <a id="phone-link" class="btn border-fade" data-analytics="phone"><i class="fa-solid fa-phone"></i> Call Me</a>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -30,6 +30,9 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .btn{display:flex;align-items:center;justify-content:center;gap:.6rem;width:100%;padding:.85rem 1.3rem;font-size:1rem;font-weight:600;color:#fff;background:var(--teal-dark);border:none;border-radius:1rem;text-decoration:none;transition:.25s;position:relative;overflow:hidden;cursor:pointer}
 .btn:hover{background:var(--orange);transform:translateY(-2px);box-shadow:0 10px 24px rgba(0,0,0,.2)}
 .btn:disabled{background:gray;opacity:.6;cursor:not-allowed}
+.border-fade{position:relative}
+.border-fade::before{content:"";position:absolute;inset:0;border:2px solid rgba(255,255,255,.4);border-radius:inherit;opacity:0;transition:opacity .2s}
+.border-fade:hover::before{opacity:1}
 /* Featured listings */
 .featured{margin-top:1rem;width:100%;text-align:left}
 .featured h3{margin-bottom:.5rem;font-size:1.2rem;color:var(--orange)}


### PR DESCRIPTION
## Summary
- add reusable `.border-fade` style for hover border transitions
- apply `border-fade` class to primary call-to-action links

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; 15 failed, 1 interrupted, 20 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ac97cc0832cb75797d73405974b