### PR TITLE
Add glowing CTA link

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
           <h1>Welcome to HecCollects</h1>
           <p>Quality • Collectibles • Community. Scroll or use the menu to explore my marketplaces and story.</p>
           <div class="links">
-            <a href="#ebay" class="btn"><i class="fa-brands fa-ebay"></i> Browse eBay Deals</a>
+            <a class="cta-glow">See in Action</a>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -30,6 +30,10 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .btn{display:flex;align-items:center;justify-content:center;gap:.6rem;width:100%;padding:.85rem 1.3rem;font-size:1rem;font-weight:600;color:#fff;background:var(--teal-dark);border:none;border-radius:1rem;text-decoration:none;transition:.25s;position:relative;overflow:hidden;cursor:pointer}
 .btn:hover{background:var(--orange);transform:translateY(-2px);box-shadow:0 10px 24px rgba(0,0,0,.2)}
 .btn:disabled{background:gray;opacity:.6;cursor:not-allowed}
+.cta-glow{position:relative;overflow:hidden;display:inline-block;padding:.85rem 1.3rem;font-size:1rem;font-weight:600;color:#fff;background:var(--teal-dark);border:none;border-radius:1rem;text-decoration:none;cursor:pointer}
+.cta-glow::before,.cta-glow::after{content:"";position:absolute;top:50%;left:50%;width:160%;height:160%;transform:translate(-50%,-50%);background:radial-gradient(circle,rgba(242,140,47,.6) 0%,transparent 70%);opacity:0;transition:opacity .4s;filter:blur(40px);z-index:-1}
+.cta-glow::after{background:radial-gradient(circle,rgba(15,97,123,.6) 0%,transparent 70%)}
+.cta-glow:hover::before,.cta-glow:hover::after{opacity:1}
 /* Featured listings */
 .featured{margin-top:1rem;width:100%;text-align:left}
 .featured h3{margin-bottom:.5rem;font-size:1.2rem;color:var(--orange)}


### PR DESCRIPTION
## Summary
- replace home call-to-action with `cta-glow` link
- style new `.cta-glow` button with animated radial gradients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1ac76ed4832c81fb928efec28acf