### PR TITLE
style hero title with gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       <div class="section-content">
         <div class="card tilt reveal">
           <img src="logo.png" alt="HecCollects Logo" class="logo" loading="lazy">
-          <h1>Welcome to HecCollects</h1>
+          <h1 class="hero-title">Welcome to HecCollects</h1>
           <p>Quality • Collectibles • Community. Scroll or use the menu to explore my marketplaces and story.</p>
           <div class="links">
             <a href="#ebay" class="btn"><i class="fa-brands fa-ebay"></i> Browse eBay Deals</a>

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z
 /* ---------- Typography ---------- */
 .logo{width:100px;height:100px;border-radius:50%;object-fit:cover;box-shadow:0 6px 14px rgba(0,0,0,.5)}
 h1{font-size:2.4rem;text-shadow:0 3px 8px rgba(0,0,0,.4)}
+.hero-title{background:linear-gradient(45deg,#fff,#d5d8f6 80%,#fdf7fe);-webkit-background-clip:text;color:transparent}
 h2{font-size:1.9rem;color:var(--orange)}
 p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 /* ---------- Buttons ---------- */

--- a/tests/hero-title.spec.ts
+++ b/tests/hero-title.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+const viewports = [
+  { name: 'mobile', width: 375, height: 667 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 800 },
+];
+
+for (const vp of viewports) {
+  test(`hero title gradient visible on ${vp.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: vp.width, height: vp.height });
+    await page.goto('file://' + filePath);
+    const heroTitle = page.locator('h1.hero-title');
+    await expect(heroTitle).toBeVisible();
+    const styles = await heroTitle.evaluate(el => {
+      const cs = getComputedStyle(el);
+      return {
+        backgroundImage: cs.backgroundImage,
+        color: cs.color,
+        clip: (cs as any).webkitBackgroundClip || (cs as any).backgroundClip,
+      };
+    });
+    expect(styles.backgroundImage).toContain('linear-gradient');
+    expect(styles.color).toBe('rgba(0, 0, 0, 0)');
+    expect(styles.clip).toBe('text');
+  });
+}


### PR DESCRIPTION
## Summary
- add `hero-title` class to landing page hero heading
- style `hero-title` with a light gradient and text clipping
- test hero title gradient visibility across mobile, tablet, and desktop viewports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a1ac680d0832cbb0f1dc59cd9a6d6