### PR TITLE
Add dropdown navigation with hover and touch support

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,13 +34,27 @@
   <header class="navbar">
     <a href="#home" class="brand">HecCollects</a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-      <a href="#home">Home</a>
-      <a href="#ebay">eBay</a>
-      <a href="#offerup">OfferUp</a>
-      <a href="#about">About Me</a>
-      <a href="#testimonials">Testimonials</a>
-      <a href="#subscribe">Subscribe</a>
-      <a href="#contact">Business Inquiries</a>
+      <ul>
+        <li><a href="#home">Home</a></li>
+        <li class="group">
+          <a href="#ebay">eBay</a>
+          <ul class="submenu">
+            <li><a href="#ebay-items">Featured Items</a></li>
+            <li><a href="https://ebay.us/m/HoUY1I" target="_blank" rel="noopener noreferrer">Store</a></li>
+          </ul>
+        </li>
+        <li class="group">
+          <a href="#offerup">OfferUp</a>
+          <ul class="submenu">
+            <li><a href="#offerup-items">Featured Items</a></li>
+            <li><a href="https://offerup.co/xluJorjDIVb" target="_blank" rel="noopener noreferrer">Listings</a></li>
+          </ul>
+        </li>
+        <li><a href="#about">About Me</a></li>
+        <li><a href="#testimonials">Testimonials</a></li>
+        <li><a href="#subscribe">Subscribe</a></li>
+        <li><a href="#contact">Business Inquiries</a></li>
+      </ul>
     </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line"></span>

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@
 
   if (burger && navMenu) {
     const links = Array.from(navMenu.querySelectorAll('a'));
+    const groups = Array.from(navMenu.querySelectorAll('.group > a'));
     const mql = window.matchMedia('(min-width: 1024px)');
 
     const openMenu = () => {
@@ -26,6 +27,7 @@
       burger.setAttribute('aria-expanded', 'true');
       navMenu.setAttribute('aria-hidden', 'false');
       links[0]?.focus();
+      groups.forEach(g => g.parentElement?.classList.add('open'));
       if (window.gtag) {
         window.gtag('event', 'menu_open');
       }
@@ -37,6 +39,7 @@
       navMenu.classList.remove('open');
       burger.setAttribute('aria-expanded', 'false');
       navMenu.setAttribute('aria-hidden', 'true');
+      groups.forEach(g => g.parentElement?.classList.remove('open'));
       if (focusBurger) burger.focus();
       if (window.gtag) {
         window.gtag('event', 'menu_close');
@@ -49,6 +52,16 @@
       } else {
         openMenu();
       }
+    });
+
+    groups.forEach(trigger => {
+      trigger.addEventListener('click', e => {
+        if (window.matchMedia('(hover: none)').matches) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          trigger.parentElement?.classList.toggle('open');
+        }
+      });
     });
 
     links.forEach(link => {

--- a/style.css
+++ b/style.css
@@ -95,6 +95,11 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .nav-menu a::after{content:"";position:absolute;left:0;bottom:-6px;width:0;height:2px;background:var(--orange);transition:width .3s}
 .nav-menu a:hover::after{width:100%}
 .nav-menu a.active{color:var(--orange)}
+.nav-menu ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;align-items:center;gap:2.4rem}
+.nav-menu li{position:relative}
+.submenu{position:absolute;top:100%;left:0;opacity:0;visibility:hidden;display:flex;flex-direction:column;background:rgba(21,21,21,.85);padding:.6rem 0;gap:.5rem;transition:opacity .3s,visibility .3s}
+.submenu a{font-size:1.2rem;padding:.4rem 1rem;white-space:nowrap}
+.group:hover .submenu,.group.open .submenu{opacity:1;visibility:visible}
 /* ---------- Responsive tweaks ---------- */
 @media(max-width:640px){
 .card{padding:1.6rem 1.2rem;gap:1rem}
@@ -108,6 +113,7 @@ section{background-attachment:fixed}
 @media(min-width:1024px){
   .nav-toggle{display:none}
   .nav-menu{position:static;transform:none;opacity:1;pointer-events:auto;flex-direction:row;gap:2rem;background:none;backdrop-filter:none;box-shadow:none;height:auto}
+  .nav-menu ul{flex-direction:row;gap:2rem}
   .nav-menu a{font-size:1rem}
   .card{max-width:900px;padding:3rem 4rem}
   .featured-items{gap:1rem;justify-content:flex-start;padding-inline:calc((100% - 250px)/2);scroll-padding-inline:calc((100% - 250px)/2)}


### PR DESCRIPTION
## Summary
- add grouped navigation items for eBay and OfferUp with submenu links
- style nav submenus with hover/transition and desktop layout tweaks
- allow touch users to toggle submenus and ensure menu opens all groups

## Testing
- `npm test` *(fails: menu navigation and scroll tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ac589a8832c9968b7dc4b873755