### PR TITLE
chore: add Playwright dev dependency and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# HecCollects.github.io
+
+## Development Setup
+
+1. Ensure you have **Node.js 18+** installed.
+
+2. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+   This installs Playwright and downloads the necessary browser binaries.
+
+3. Run the test suite:
+
+   ```bash
+   npm test
+   ```
+
+   Playwright Test will execute the browser-based tests.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.54.2"
+        "@playwright/test": "^1.54.2",
+        "playwright": "^1.54.2"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.54.2"
+    "@playwright/test": "^1.54.2",
+    "playwright": "^1.54.2"
   }
 }


### PR DESCRIPTION
## Summary
- add Playwright as a dev dependency
- regenerate package-lock.json
- document project setup and tests in README

## Testing
- `npm test` *(fails: 36 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a1f560b3c832c93b904f32edc56a8