### PR TITLE
Add fallback href for phone contact link

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
           <div class="links">
             <a href="mailto:hectorsandoval1402@gmail.com" class="btn border-fade" data-analytics="email"><i class="fa-solid fa-envelope"></i> Email Me</a>
             <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="instagram"><i class="fa-brands fa-instagram"></i> Instagram</a>
-            <a id="phone-link" class="btn border-fade" data-analytics="phone"><i class="fa-solid fa-phone"></i> Call Me</a>
+            <a id="phone-link" href="#contact" class="btn border-fade" data-analytics="phone"><i class="fa-solid fa-phone"></i> Call Me</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure phone contact link is focusable by adding a fallback `href`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a1f53c018832ca1eacadf4f777481