### PR TITLE
fix cta glow stacking

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,10 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .border-fade{position:relative}
 .border-fade::before{content:"";position:absolute;inset:0;border:2px solid rgba(255,255,255,.4);border-radius:inherit;opacity:0;transition:opacity .2s}
 .border-fade:hover::before{opacity:1}
+.cta-glow{position:relative;z-index:0}
+.cta-glow::before,.cta-glow::after{content:"";position:absolute;inset:0;border-radius:inherit;pointer-events:none}
+.cta-glow::before{z-index:-1;background:transparent;box-shadow:0 0 16px var(--orange)}
+.cta-glow::after{z-index:0;mix-blend-mode:overlay}
 /* Featured listings */
 .featured{margin-top:1rem;width:100%;text-align:left}
 .featured h3{margin-bottom:.5rem;font-size:1.2rem;color:var(--orange)}


### PR DESCRIPTION
## Summary
- ensure `.cta-glow` forms its own stacking context and layers glow pseudo-elements correctly

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `node -e` (checked `.cta-glow::before` z-index and border radius)


------
https://chatgpt.com/codex/tasks/task_e_689a1f546e78832c8e5b6fef997e7d2a