### PR TITLE
Add feature marquee overflow and list styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,3 +152,7 @@ animation: none !important;
 transition: none !important;
 }
 }
+
+.feature-marquee{overflow:hidden}
+.feature-marquee ul{list-style:none;white-space:nowrap}
+.feature-marquee li{display:inline-block;padding:0 1rem}


### PR DESCRIPTION
## Summary
- add `.feature-marquee` overflow rule
- remove bullets and enforce single-line flow in `.feature-marquee ul`
- pad marquee items for consistent spacing

## Testing
- `npm test` *(fails: preloader-ripple.spec.ts expected <1000ms, received 1010ms)*

------
https://chatgpt.com/codex/tasks/task_e_689a24ceffdc832cb1c32ce5b4295523