### PR TITLE
refactor: clone list items without innerHTML

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,25 @@
     }
   }
 
+  const initListClones = () => {
+    if (window.__listClonesInitialized) return;
+    window.__listClonesInitialized = true;
+    document.querySelectorAll('ul').forEach(list => {
+      const originals = Array.from(list.children);
+      originals.forEach(li => {
+        const clone = li.cloneNode(true);
+        clone.setAttribute('aria-hidden', 'true');
+        list.appendChild(clone);
+      });
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initListClones, { once: true });
+  } else {
+    initListClones();
+  }
+
   const burger = document.querySelector('.nav-toggle');
   const navMenu = document.getElementById('nav-menu');
 


### PR DESCRIPTION
## Summary
- clone `<li>` elements using `cloneNode` and mark clones `aria-hidden`
- initialize list cloning once after DOM ready to prevent duplication

## Testing
- `npm test` *(fails: preloader is removed and ripple cleans up – Expected: < 1000, Received: 1043)*

------
https://chatgpt.com/codex/tasks/task_e_689a24cffbe0832ca6c48b28c77e2479