### PR TITLE
Add feature marquee test and duplication logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,11 @@
             <a href="#ebay" class="btn border-fade"><i class="fa-brands fa-ebay"></i> Browse eBay Deals</a>
           </div>
         </div>
+        <ul class="feature-marquee">
+          <li>Trusted seller</li>
+          <li>Fast shipping</li>
+          <li>Collector-friendly pricing</li>
+        </ul>
       </div>
     </section>
 

--- a/main.js
+++ b/main.js
@@ -116,15 +116,21 @@
   });
 
   // Scroll cues
-  document.querySelectorAll('section:not(:last-of-type)').forEach(section => {
-    const cue = document.createElement('span');
-    cue.className = 'scroll-cue';
-    cue.textContent = 'Swipe / scroll ↓';
-    section.appendChild(cue);
-  });
+    document.querySelectorAll('section:not(:last-of-type)').forEach(section => {
+      const cue = document.createElement('span');
+      cue.className = 'scroll-cue';
+      cue.textContent = 'Swipe / scroll ↓';
+      section.appendChild(cue);
+    });
 
-  // Ripple
-  document.querySelectorAll('.btn').forEach(btn => {
+    // Feature marquee: duplicate items for seamless scroll
+    document.querySelectorAll('.feature-marquee').forEach(list => {
+      const items = Array.from(list.children);
+      items.forEach(item => list.appendChild(item.cloneNode(true)));
+    });
+
+    // Ripple
+    document.querySelectorAll('.btn').forEach(btn => {
     const showRipple = (x, y) => {
       const circle = document.createElement('span');
       const size = Math.max(btn.clientWidth, btn.clientHeight);

--- a/style.css
+++ b/style.css
@@ -50,6 +50,9 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .item-meta{position:absolute;top:.4rem;left:.4rem;background:var(--orange);color:var(--black);padding:.2rem .4rem;border-radius:.4rem;font-size:.7rem;font-weight:600}
 .featured-items a:hover img{transform:scale(1.08);box-shadow:0 8px 16px rgba(0,0,0,.4)}
 .promo{margin-top:.8rem;font-size:.9rem;color:var(--orange)}
+/* Feature marquee */
+.feature-marquee{display:flex;overflow:hidden;list-style:none;gap:2rem;padding:0;margin:1rem 0;width:100%}
+.feature-marquee li{white-space:nowrap;flex:0 0 auto}
 /* Carousel */
 .carousel{position:relative;display:flex;align-items:center}
 .carousel-btn{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.45);color:#fff;border:none;border-radius:50%;width:32px;height:32px;cursor:pointer;z-index:2}

--- a/tests/marquee.spec.ts
+++ b/tests/marquee.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+test('feature marquee duplicates items for seamless scrolling', async ({ page }) => {
+  await page.goto('file://' + filePath);
+  const marquee = page.locator('.feature-marquee');
+  await expect(marquee).toBeVisible();
+  const items = marquee.locator('li');
+  const count = await items.count();
+  expect(count).toBeGreaterThan(0);
+  expect(count % 2).toBe(0);
+  const texts = await items.allInnerTexts();
+  const half = count / 2;
+  expect(texts.slice(0, half)).toEqual(texts.slice(half));
+});


### PR DESCRIPTION
## Summary
- Add feature marquee element with duplicated items for seamless scrolling
- Style marquee to prevent layout overflow on mobile
- Introduce Playwright test covering marquee duplication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a24d10464832c9a4ffe208f25ad8f