### PR TITLE
refactor: consolidate feature marquee styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -156,6 +156,3 @@ transition: none !important;
 }
 }
 
-.feature-marquee{overflow:hidden}
-.feature-marquee ul{list-style:none;white-space:nowrap}
-.feature-marquee li{display:inline-block;padding:0 1rem}


### PR DESCRIPTION
## Summary
- remove duplicated `.feature-marquee` CSS block

## Testing
- `npm test` *(fails: GA script loads with integrity, featured items are in viewport and clickable, feature marquee duplicates items for seamless scrolling, menu supports keyboard navigation, preloader is removed and ripple cleans up, navigation links scroll to correct sections, section home is visible, section ebay is visible, featured items are in viewport and clickable, feature marquee duplicates items for seamless scrolling, section offerup is visible, section about is visible, menu supports keyboard navigation, section testimonials is visible, preloader is removed and ripple cleans up, section subscribe is visible, navigation links scroll to correct sections, section contact is visible, section home is visible, GA script loads with integrity, section ebay is visible, section offerup is visible, featured items are in viewport and clickable)*

------
https://chatgpt.com/codex/tasks/task_e_689a3150b53c832c808ea7b53b32668a