### PR TITLE
Remove GA SRI and update analytics test

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -4,7 +4,6 @@
   const script = document.createElement('script');
   script.async = true;
   script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-  script.integrity = 'sha256-Otare2YpYU85tTuCOT36b10VBDtZIGOpaDskQaLvDCA=';
   script.crossOrigin = 'anonymous';
   document.head.appendChild(script);
 

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -3,13 +3,15 @@ import path from 'path';
 
 const filePath = path.resolve(__dirname, '../index.html');
 
-// Ensure the GA script tag is injected and no console errors occur.
-test('GA script loads with integrity', async ({ page }) => {
+// Ensure the GA script tag is injected and analytics configuration runs.
+test('GA script loads and configures GA', async ({ page }) => {
   await page.addInitScript(() => {
     (window as any).GA_ID = 'G-TESTID';
   });
 
-  await page.goto('file://' + filePath);
+  await page.route('https://www.googletagmanager.com/**', route => {
+    route.fulfill({ status: 200, body: '' });
+  });
 
   page.on('console', msg => {
     if (msg.type() === 'error') {
@@ -17,10 +19,21 @@ test('GA script loads with integrity', async ({ page }) => {
     }
   });
 
+  await page.goto('file://' + filePath);
+
   await page.waitForSelector(
-    'script[src*="googletagmanager.com/gtag/js"][integrity]',
+    'script[src*="googletagmanager.com/gtag/js"]',
     { state: 'attached' }
   );
-  const integrity = await page.getAttribute('script[src*="googletagmanager.com/gtag/js"]', 'integrity');
-  expect(integrity).toBeTruthy();
+
+  const { gtagDefined, configEvent } = await page.evaluate(() => {
+    const dataLayer = (window as any).dataLayer || [];
+    return {
+      gtagDefined: typeof (window as any).gtag === 'function',
+      configEvent: dataLayer.some((entry: any[]) => entry[0] === 'config' && entry[1] === 'G-TESTID'),
+    };
+  });
+
+  expect(gtagDefined).toBe(true);
+  expect(configEvent).toBe(true);
 });


### PR DESCRIPTION
## Summary
- drop static integrity hash from analytics script so GA can load without mismatches
- adjust analytics test to stub GA script and verify gtag configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a366f78dc832ca677a25cbc53e386