### PR TITLE
Handle featured item fetch errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -241,6 +241,12 @@
     });
   };
 
+  const showFallbackMessage = () => {
+    document.querySelectorAll('.featured-items').forEach(container => {
+      container.textContent = 'Unable to load items at this time.';
+    });
+  };
+
   // Load featured items
   if (location.protocol !== 'file:') {
     fetch('items.json')
@@ -285,7 +291,10 @@
         buildItems('offerup', 'offerup-items');
         initFeaturedCarousels();
       })
-      .catch(() => {});
+      .catch(err => {
+        console.error(err);
+        showFallbackMessage();
+      });
   } else {
     initFeaturedCarousels();
   }


### PR DESCRIPTION
## Summary
- Log failures when fetching featured items
- Display a fallback notice if items cannot be loaded

## Testing
- `npm test` *(fails: 39 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a43641be4832c99e4b984937019c1