### PR TITLE
Add theme-color meta tag for mobile browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <meta name="twitter:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta name="twitter:url" content="https://heccollects.github.io/" />
   <meta name="twitter:image" content="https://heccollects.github.io/logo.png" />
+  <meta name="theme-color" content="#0f617b" />
   <title>HecCollects – Landing Page</title>
 
   <!-- Fonts and icons -->

--- a/tests/theme-color.spec.ts
+++ b/tests/theme-color.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+test('sets theme-color meta tag', async ({ page }) => {
+  await page.goto('file://' + filePath);
+  const themeColor = page.locator('meta[name="theme-color"]');
+  await expect(themeColor).toHaveAttribute('content', '#0f617b');
+});


### PR DESCRIPTION
## Summary
- Set a theme-color meta tag to the brand teal for mobile UI chrome
- Add Playwright test to ensure theme-color meta tag is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a45015c20832c9d295acdc5626423