### PR TITLE
docs: document analytics and phone configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@
 
 Playwright Test will execute the browser-based tests.
 
+## Configuration
+
+`config.js` reads optional values from the global `window` object.
+Provide these at deploy time by defining them before the script loads or by
+replacing them during your build (for example via environment variables).
+
+- `window.GA_ID` – Google Analytics tracking ID.
+- `window.PHONE_NUMBER` – Contact number used for the phone link.
+
+If left unset, analytics is disabled and the phone link will be hidden.
+
 ## Animated Background Prototype
 
 Evaluated libraries for a lightweight animated hero background:

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
-// Google Analytics tracking ID. Replace with your real ID.
-// Preserve any existing value so tests or environment scripts can set it.
+// Google Analytics tracking ID. Inject via deployment environment or build-time replacement.
+// Existing value is preserved so tests or environment scripts can set it.
 window.GA_ID = window.GA_ID || '';
 // reCAPTCHA site key. Replace with a real key for production.
 window.RECAPTCHA_SITE_KEY = window.RECAPTCHA_SITE_KEY || '';
-// Contact phone number without the tel: prefix.
+// Contact phone number without the tel: prefix. Inject via deployment environment or build-time replacement.
 window.PHONE_NUMBER = window.PHONE_NUMBER || '';

--- a/main.js
+++ b/main.js
@@ -4,6 +4,13 @@
     recaptcha.setAttribute('data-sitekey', window.RECAPTCHA_SITE_KEY);
   }
 
+  if (!window.GA_ID) {
+    console.warn('window.GA_ID is not set; analytics will be disabled.');
+  }
+  if (!window.PHONE_NUMBER) {
+    console.warn('window.PHONE_NUMBER is not set; phone link will be hidden.');
+  }
+
   const phoneLink = document.getElementById('phone-link');
   if (phoneLink) {
     if (window.PHONE_NUMBER) {


### PR DESCRIPTION
## Summary
- explain how `window.GA_ID` and `window.PHONE_NUMBER` are supplied via environment or build-time replacement
- warn in `main.js` when GA_ID or phone number are missing

## Testing
- `npx playwright install`
- `npx playwright install-deps`
- `npm test` *(fails: preloader ripple cleanup exceeds 1000ms)*

------
https://chatgpt.com/codex/tasks/task_e_689a56480a94832c8d948329b3aefad0