### PR TITLE
Hide scroll cue from screen readers

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,6 @@
     } else {
       recaptcha.classList.add('hidden');
     }
-codex/update-comments-and-readme-for-ga_id-and-phone_number
   }
 
   if (!window.GA_ID) {
@@ -15,7 +14,6 @@ codex/update-comments-and-readme-for-ga_id-and-phone_number
   }
   if (!window.PHONE_NUMBER) {
     console.warn('window.PHONE_NUMBER is not set; phone link will be hidden.');
-main
   }
 
   const phoneLink = document.getElementById('phone-link');
@@ -153,6 +151,8 @@ main
       const cue = document.createElement('span');
       cue.className = 'scroll-cue';
       cue.textContent = 'Swipe / scroll ↓';
+      cue.setAttribute('aria-hidden', 'true');
+      cue.setAttribute('role', 'presentation');
       section.appendChild(cue);
     });
 

--- a/tests/scroll-cue.spec.ts
+++ b/tests/scroll-cue.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+test('scroll cues are visible but hidden from assistive tech', async ({ page }) => {
+  await page.goto('file://' + filePath);
+  const cues = page.locator('.scroll-cue');
+  const count = await cues.count();
+  expect(count).toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    const cue = cues.nth(i);
+    await expect(cue).toBeVisible();
+    await expect(cue).toHaveAttribute('aria-hidden', 'true');
+    await expect(cue).toHaveAttribute('role', 'presentation');
+  }
+});


### PR DESCRIPTION
## Summary
- hide scroll cue spans from assistive technology with `aria-hidden` and presentation role
- test scroll cue visibility and hidden attributes

## Testing
- `npx playwright install`
- `npx playwright install-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a639f0298832cac8a7998933b6056