### PR TITLE
Add media query listener fallback

### DIFF
--- a/main.js
+++ b/main.js
@@ -129,7 +129,11 @@
       }
     };
     handleBreakpoint(mql);
-    mql.addEventListener('change', handleBreakpoint);
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', handleBreakpoint);
+    } else if (mql.addListener) {
+      mql.addListener(handleBreakpoint);
+    }
   }
 
   // Outbound click tracking
@@ -438,13 +442,18 @@
       vantaEffect = null;
     };
 
-    motionQuery.addEventListener('change', e => {
+    const handleMotionChange = (e) => {
       if (e.matches) {
         destroyVanta();
       } else {
         initVanta();
       }
-    });
+    };
+    if (typeof motionQuery.addEventListener === 'function') {
+      motionQuery.addEventListener('change', handleMotionChange);
+    } else if (motionQuery.addListener) {
+      motionQuery.addListener(handleMotionChange);
+    }
 
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', initVanta, { once: true });


### PR DESCRIPTION
## Summary
- handle navigation menu breakpoint with addEventListener fallback to addListener
- use addListener fallback for Vanta motion preference query

## Testing
- `npm test` *(fails: GA script loads and configures GA, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a69427650832c90026a55add61746