### PR TITLE
feat: tighten content security policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:" />
   <meta property="og:title" content="HecCollects – Landing Page" />
   <meta property="og:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
   <meta property="og:url" content="https://heccollects.github.io/" />
@@ -31,19 +31,7 @@
     <script src="analytics.js"></script>
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14'>🚀</text></svg>'">
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "Organization",
-        "name": "HecCollects",
-        "url": "https://heccollects.github.io/",
-        "logo": "https://heccollects.github.io/logo.png",
-        "sameAs": [
-          "https://ebay.us/m/HoUY1I",
-          "https://offerup.co/xluJorjDIVb"
-        ]
-      }
-    </script>
+    <script type="application/ld+json" src="schema.json"></script>
   </head>
 <body>
     <div id="preloader"><div class="dotted-loader"></div></div>

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "HecCollects",
+  "url": "https://heccollects.github.io/",
+  "logo": "https://heccollects.github.io/logo.png",
+  "sameAs": [
+    "https://ebay.us/m/HoUY1I",
+    "https://offerup.co/xluJorjDIVb"
+  ]
+}


### PR DESCRIPTION
## Summary
- tighten script-src by dropping 'unsafe-inline'
- externalize JSON-LD into schema.json to avoid inline scripts

## Testing
- `npm test` *(fails: Host system is missing libraries such as libgtk-4.so.1 and libx264.so, 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a6b2ccd40832c8c63644efd900499