### PR TITLE
feat: add package reveal animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
     <section id="home">
       <div class="section-content">
         <div class="card tilt reveal">
-          <span>
+          <div id="package-anim" class="package-anim">
             <img src="logo.png" alt="HecCollects logo" class="logo" loading="lazy">
-          </span>
+          </div>
           <h1>Welcome to HecCollects</h1>
           <p>Quality • Collectibles • Community. Scroll or use the menu to explore my marketplaces and story.</p>
           <div class="links">

--- a/main.js
+++ b/main.js
@@ -475,6 +475,87 @@
     });
   }
 
+  // Package reveal animation
+  const packageContainer = document.getElementById('package-anim');
+  if (packageContainer && window.THREE) {
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) {
+      packageContainer.classList.add('show-logo');
+    } else {
+      let renderer, scene, camera, lid, logoMesh, animId, startTime, progress = 0;
+      const init = () => {
+        const { clientWidth: w, clientHeight: h } = packageContainer;
+        renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+        renderer.setSize(w, h);
+        packageContainer.appendChild(renderer.domElement);
+        scene = new THREE.Scene();
+        camera = new THREE.PerspectiveCamera(45, w / h, 0.1, 100);
+        camera.position.set(0, 1.5, 4);
+        const material = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
+        const box = new THREE.Mesh(new THREE.BoxGeometry(2, 1, 2), material);
+        box.position.y = -0.5;
+        scene.add(box);
+        lid = new THREE.Mesh(new THREE.BoxGeometry(2, 0.1, 2), material);
+        lid.position.y = 0.05;
+        scene.add(lid);
+        const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+        scene.add(light);
+        const tex = new THREE.TextureLoader().load('logo.png');
+        const plane = new THREE.PlaneGeometry(1.2, 1.2);
+        const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
+        logoMesh = new THREE.Mesh(plane, mat);
+        logoMesh.rotation.x = -Math.PI / 2;
+        logoMesh.position.y = -0.1;
+        logoMesh.visible = false;
+        scene.add(logoMesh);
+        renderer.render(scene, camera);
+      };
+      const step = (t) => {
+        if (!startTime) startTime = t;
+        const delta = t - startTime;
+        startTime = t;
+        progress = Math.min(progress + delta / 1000, 1);
+        lid.rotation.x = -Math.PI / 2 * progress;
+        if (progress >= 1) {
+          logoMesh.visible = true;
+          packageContainer.classList.add('show-logo');
+        }
+        renderer.render(scene, camera);
+        if (progress < 1) animId = requestAnimationFrame(step);
+        else animId = null;
+      };
+      const play = () => {
+        if (animId || progress >= 1) return;
+        startTime = null;
+        animId = requestAnimationFrame(step);
+      };
+      const pause = () => {
+        if (animId) {
+          cancelAnimationFrame(animId);
+          animId = null;
+        }
+      };
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            if (!renderer) init();
+            play();
+          } else {
+            pause();
+          }
+        });
+      }, { threshold: 0.5 });
+      observer.observe(packageContainer);
+      packageContainer.addEventListener('click', () => {
+        lid.rotation.x = 0;
+        logoMesh.visible = false;
+        packageContainer.classList.remove('show-logo');
+        progress = 0;
+        play();
+      });
+    }
+  }
+
   // Subscribe form handling with honeypot and reCAPTCHA
   const subscribeForm = document.querySelector('.subscribe-form');
   if(subscribeForm){

--- a/style.css
+++ b/style.css
@@ -160,3 +160,8 @@ transition: none !important;
 }
 }
 
+
+.package-anim{position:relative;width:200px;height:200px;margin:0 auto 1rem}
+.package-anim canvas{width:100%;height:100%}
+.package-anim .logo{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;opacity:0;transition:opacity .5s}
+.package-anim.show-logo .logo{opacity:1}


### PR DESCRIPTION
## Summary
- add Three.js package animation revealing logo
- pause/replay animation based on viewport and motion preferences

## Testing
- `npm test` *(fails: GA script loads and preloader ripple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ab2c5dcac832c9e14f1c865e20cdb