### PR TITLE
Handle history navigation for fade transitions

### DIFF
--- a/page-transitions.js
+++ b/page-transitions.js
@@ -1,6 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
   const body = document.body;
-  body.classList.add('fade-in');
+
+  const show = () => {
+    body.classList.remove('fade-out');
+    body.classList.add('fade-in');
+  };
+
+  show();
+  window.addEventListener('pageshow', show);
 
   document.querySelectorAll('a[href]').forEach(link => {
     const target = link.getAttribute('target');

--- a/theme.css
+++ b/theme.css
@@ -9,6 +9,7 @@ body {
   transition: background 0.4s ease-in-out, opacity 0.4s ease-in-out;
   opacity: 0;
   position: relative;
+  z-index: 0;
 }
 
 body::before {


### PR DESCRIPTION
## Summary
- Ensure page content fades back in when returning via browser history
- Keep interactive elements above background overlay

## Testing
- `npm test` *(fails: GA script loads and configures GA, menu supports keyboard navigation, preloader is removed and ripple cleans up, navigation links scroll to correct sections)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a45277c832c96d242b6d2927fd9