### PR TITLE
feat: add marquee background wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,16 @@
           </div>
         </div>
         <div class="feature-marquee-container">
-          <ul class="feature-marquee">
-            <li>Trusted seller</li>
-            <li>Fast shipping</li>
-            <li>Collector-friendly pricing</li>
-          </ul>
+          <div class="marquee-background">
+            <ul class="feature-marquee">
+              <li>Trusted seller</li>
+              <li>Fast shipping</li>
+              <li>Collector-friendly pricing</li>
+              <li>Trusted seller</li>
+              <li>Fast shipping</li>
+              <li>Collector-friendly pricing</li>
+            </ul>
+          </div>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -169,8 +169,16 @@ transition: none !important;
 
 /* Background feature marquee */
 .feature-marquee-container{position:absolute;inset:0;z-index:-1;pointer-events:none;overflow:hidden}
-.feature-marquee{position:absolute;inset:0;margin:0;padding:0;list-style:none;color:var(--orange);opacity:.15;perspective:1000px;transform-style:preserve-3d}
-@keyframes marquee-depth{from{transform:translateZ(-600px) translate(0,0)}to{transform:translateZ(0) translate(100px,-100px)}}
-.feature-marquee li{position:absolute;animation:marquee-depth 20s linear infinite}
-.feature-marquee li:nth-child(2n){animation-delay:5s}
-.feature-marquee li:nth-child(3n){animation-delay:10s}
+.marquee-background{position:absolute;z-index:-1;inset:0;pointer-events:none}
+.feature-marquee{position:absolute;inset:0;margin:0;padding:0;list-style:none;color:var(--orange);opacity:.15}
+.feature-marquee li{position:absolute;white-space:nowrap}
+.feature-marquee li:nth-child(1){top:10%;left:5%;animation:marquee-tr 20s linear infinite}
+.feature-marquee li:nth-child(2){top:30%;right:10%;animation:marquee-bl 22s linear infinite}
+.feature-marquee li:nth-child(3){bottom:15%;left:40%;animation:marquee-br 24s linear infinite}
+.feature-marquee li:nth-child(4){top:60%;left:70%;animation:marquee-tl 26s linear infinite}
+.feature-marquee li:nth-child(5){bottom:30%;right:20%;animation:marquee-tr 28s linear infinite}
+.feature-marquee li:nth-child(6){top:80%;left:20%;animation:marquee-bl 30s linear infinite}
+@keyframes marquee-tr{from{transform:translate(0,0)}to{transform:translate(100px,-100px)}}
+@keyframes marquee-bl{from{transform:translate(0,0)}to{transform:translate(-100px,100px)}}
+@keyframes marquee-br{from{transform:translate(0,0)}to{transform:translate(100px,100px)}}
+@keyframes marquee-tl{from{transform:translate(0,0)}to{transform:translate(-100px,-100px)}}


### PR DESCRIPTION
## Summary
- scatter feature marquee items across home section in multiple directions
- repeat marquee entries to cover more of the page background

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/... — run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a420240832cb591e4e86f925bad