### PR TITLE
Ensure marquee text animates sequentially

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,12 +73,9 @@
         <div class="feature-marquee-container">
           <div class="marquee-background">
             <ul class="feature-marquee">
-              <li>Trusted seller</li>
-              <li>Fast shipping</li>
-              <li>Collector-friendly pricing</li>
-              <li>Trusted seller</li>
-              <li>Fast shipping</li>
-              <li>Collector-friendly pricing</li>
+              <li style="--i: 0">Trusted seller</li>
+              <li style="--i: 1">Fast shipping</li>
+              <li style="--i: 2">Collector-friendly pricing</li>
             </ul>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -30,9 +30,12 @@
     window.__listClonesInitialized = true;
     document.querySelectorAll('.feature-marquee').forEach(list => {
       const originals = Array.from(list.children);
-      originals.forEach(li => {
+      originals.forEach((li, index) => {
         const clone = li.cloneNode(true);
         clone.setAttribute('aria-hidden', 'true');
+        const delayIndex = originals.length + index;
+        clone.style.setProperty('--i', delayIndex);
+        clone.style.animationDelay = `${delayIndex * 4}s`;
         list.appendChild(clone);
       });
     });

--- a/style.css
+++ b/style.css
@@ -192,6 +192,5 @@ transition: none !important;
     position: absolute;
     animation: marquee-depth 12s linear infinite;
     transform-style: preserve-3d;
+    animation-delay: calc(var(--i) * 4s);
   }
-  .feature-marquee li:nth-child(2) { animation-delay: 4s; }
-  .feature-marquee li:nth-child(3) { animation-delay: 8s; }


### PR DESCRIPTION
## Summary
- Deduplicate feature marquee entries to a single trio of messages
- Drive sequential marquee delays via CSS variables and JS cloning
- Drop hard-coded nth-child animation delays

## Testing
- `npx playwright test` *(fails: 8 failed, 37 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689b532bdafc832c83e851b62a60d863