### PR TITLE
chore: remove stray feature marquee line

### DIFF
--- a/style.css
+++ b/style.css
@@ -194,7 +194,6 @@ transition: none !important;
     transform-style: preserve-3d;
     animation-delay: calc(var(--i) * 4s);
   }
- codex/update-feature-marquee-animations-and-styles
   .feature-marquee li:nth-child(2) { animation-delay: 4s; }
   .feature-marquee li:nth-child(3) { animation-delay: 8s; }
 @supports not (height:100dvh){section{height:100vh;min-height:100vh}}


### PR DESCRIPTION
## Summary
- remove leftover `codex/update-feature-marquee-animations-and-styles` line from feature marquee styles

## Testing
- `npm test` *(fails: 15 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ebb934c832ca19b922d5ab91495