### PR TITLE
Add FAQ and returns policy pages with site footer

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FAQ - HecCollects</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="theme.css">
+</head>
+<body>
+  <main class="privacy-content">
+    <h1>Frequently Asked Questions</h1>
+    <section>
+      <h2>Shipping</h2>
+      <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier.</p>
+    </section>
+    <section>
+      <h2>Returns</h2>
+      <p>Returns are accepted within 30 days of delivery. Items must be returned in original condition for a full refund.</p>
+    </section>
+    <section>
+      <h2>Communication</h2>
+      <p>I respond to all messages within 24 hours. Feel free to reach out for any questions or special requests.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <a href="index.html">Home</a>
+    <a href="returns.html">Returns</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </footer>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How long does shipping take?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Orders are packed within 2 business days and typically arrive within 3-5 business days."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is your return policy?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Returns are accepted within 30 days of delivery if items are in original condition."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "When can I expect a response to my message?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "I aim to respond to all inquiries within 24 hours."
+        }
+      }
+    ]
+  }
+  </script>
+  <script src="page-transitions.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,8 @@
       <a href="#testimonials" tabindex="0">Testimonials</a>
       <a href="#subscribe" tabindex="0">Subscribe</a>
       <a href="#contact" tabindex="0">Business Inquiries</a>
+      <a href="faq.html" tabindex="0">FAQ</a>
+      <a href="returns.html" tabindex="0">Returns</a>
     </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line"></span>
@@ -235,6 +237,13 @@
       </div>
     </section>
   </main>
+
+  <footer class="site-footer">
+    <a href="#home">Home</a>
+    <a href="faq.html">FAQ</a>
+    <a href="returns.html">Returns</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </footer>
 
   <div id="cookie-banner" class="cookie-banner hidden" role="dialog" aria-live="polite">
     <span>This site uses cookies and analytics to improve your experience.</span>

--- a/privacy.html
+++ b/privacy.html
@@ -14,6 +14,12 @@
     <p>We use analytics to understand how visitors interact with the site. This helps improve content and user experience. Cookies may be stored on your device for this purpose.</p>
     <p>Your data will never be sold to third parties. For questions about this policy, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
   </main>
+  <footer class="site-footer">
+    <a href="index.html">Home</a>
+    <a href="faq.html">FAQ</a>
+    <a href="returns.html">Returns</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </footer>
   <script src="page-transitions.js" defer></script>
 </body>
 </html>

--- a/returns.html
+++ b/returns.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shipping & Returns - HecCollects</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="theme.css">
+</head>
+<body>
+  <main class="privacy-content">
+    <h1>Shipping & Returns</h1>
+    <section>
+      <h2>Shipping Policy</h2>
+      <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available.</p>
+    </section>
+    <section>
+      <h2>Returns Policy</h2>
+      <p>Returns are accepted within 30 days of delivery. Items should be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
+    </section>
+    <section>
+      <h2>Communication Expectations</h2>
+      <p>I strive to answer all messages within 24 hours. Reach out with any order questions and I'll work to make things right.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <a href="index.html">Home</a>
+    <a href="faq.html">FAQ</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </footer>
+  <script src="page-transitions.js" defer></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -198,3 +198,7 @@ transition: none !important;
   .feature-marquee li:nth-child(3) { animation-delay: 8s; }
 @supports not (height:100dvh){section{height:100vh;min-height:100vh}}
 main
+
+.site-footer{padding:1rem;text-align:center;color:var(--white);}
+.site-footer a{color:var(--color-accent);margin:0 .5rem;text-decoration:none;}
+.site-footer a:hover{text-decoration:underline;}


### PR DESCRIPTION
## Summary
- add FAQ page with shipping, returns, communication sections and JSON-LD structured data
- add shipping & returns policy page
- link new pages from navigation and new footer styled in CSS

## Testing
- `npm test` *(fails: 48 failed tests after Playwright browser install)*

------
https://chatgpt.com/codex/tasks/task_e_689b66e57cc4832c89ca4ed349cb99ac