### PR TITLE
Add theme toggle with dark mode variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,25 +50,28 @@
     </script>
  main
   </head>
-<body>
+  <body data-theme="light">
     <div id="preloader"><div class="dotted-loader"></div></div>
   <!-- Navbar -->
   <header class="navbar">
     <a href="#home" class="brand" tabindex="0">HecCollects</a>
-    <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-      <a href="#home" tabindex="0">Home</a>
-      <a href="#ebay" tabindex="0">eBay</a>
-      <a href="#offerup" tabindex="0">OfferUp</a>
-      <a href="#about" tabindex="0">About Me</a>
-      <a href="#testimonials" tabindex="0">Testimonials</a>
-      <a href="#subscribe" tabindex="0">Subscribe</a>
-      <a href="#contact" tabindex="0">Business Inquiries</a>
-    </nav>
-    <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
-      <span class="line"></span>
-      <span class="line"></span>
-      <span class="line"></span>
-    </button>
+      <nav id="nav-menu" class="nav-menu" aria-hidden="true">
+        <a href="#home" tabindex="0">Home</a>
+        <a href="#ebay" tabindex="0">eBay</a>
+        <a href="#offerup" tabindex="0">OfferUp</a>
+        <a href="#about" tabindex="0">About Me</a>
+        <a href="#testimonials" tabindex="0">Testimonials</a>
+        <a href="#subscribe" tabindex="0">Subscribe</a>
+        <a href="#contact" tabindex="0">Business Inquiries</a>
+      </nav>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+        <i class="fa-solid fa-moon"></i>
+      </button>
+      <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
+        <span class="line"></span>
+        <span class="line"></span>
+        <span class="line"></span>
+      </button>
   </header>
 
   <!-- Sections -->
@@ -242,9 +245,10 @@
   </div>
 
   <!-- ---------- JS: interactions & animations ---------- -->
-    <script src="vendor/three.min.js" defer></script>
-    <script src="vendor/vanta.net.min.js" defer></script>
-    <script src="main.js" defer></script>
-    <script src="page-transitions.js" defer></script>
+      <script src="vendor/three.min.js" defer></script>
+      <script src="vendor/vanta.net.min.js" defer></script>
+      <script src="theme-toggle.js" defer></script>
+      <script src="main.js" defer></script>
+      <script src="page-transitions.js" defer></script>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -7,13 +7,14 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
 </head>
-<body>
-  <main class="privacy-content">
+  <body data-theme="light">
+    <main class="privacy-content">
     <h1>Privacy Policy</h1>
     <p>We value your privacy. Any information submitted through this site is used solely to communicate updates and offers from HecCollects.</p>
     <p>We use analytics to understand how visitors interact with the site. This helps improve content and user experience. Cookies may be stored on your device for this purpose.</p>
     <p>Your data will never be sold to third parties. For questions about this policy, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
   </main>
-  <script src="page-transitions.js" defer></script>
-</body>
+    <script src="theme-toggle.js" defer></script>
+    <script src="page-transitions.js" defer></script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -198,3 +198,5 @@ transition: none !important;
   .feature-marquee li:nth-child(3) { animation-delay: 8s; }
 @supports not (height:100dvh){section{height:100vh;min-height:100vh}}
 main
+
+[data-theme="dark"]{--color-primary:#0d1117;--color-secondary:#161b22;--color-accent:#f28c2f;--white:#e6edf3;--black:#010409}.theme-toggle{background:none;border:none;color:var(--white);cursor:pointer;font-size:1.25rem;margin-left:1rem}

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -1,0 +1,18 @@
+const storageKey = 'theme';
+const body = document.body;
+const toggle = document.getElementById('theme-toggle');
+
+function setTheme(theme) {
+  body.setAttribute('data-theme', theme);
+  localStorage.setItem(storageKey, theme);
+}
+
+const saved = localStorage.getItem(storageKey);
+if (saved) {
+  setTheme(saved);
+}
+
+toggle?.addEventListener('click', () => {
+  const current = body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+  setTheme(current);
+});


### PR DESCRIPTION
## Summary
- add light/dark data-theme attribute and navbar theme toggle
- persist theme preference in localStorage with new module
- define dark mode CSS variables

## Testing
- `npm test` *(fails: analytics loading and preloader cleanup tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b66f80650832c9002b7fc0c121f2a