### PR TITLE
Specify image size and preconnect

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <!-- Fonts and icons -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://www.marchingdogs.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 

--- a/main.js
+++ b/main.js
@@ -306,6 +306,19 @@
             img.src = item.image;
             img.alt = item.alt;
             img.loading = 'lazy';
+            try {
+              const url = new URL(item.image);
+              const widthParam = url.searchParams.get('width');
+              if (widthParam) {
+                const width = parseInt(widthParam, 10);
+                const half = Math.round(width / 2);
+                const small = new URL(item.image);
+                small.searchParams.set('width', String(half));
+                img.width = width;
+                img.height = width;
+                img.srcset = `${small.toString()} ${half}w, ${item.image} ${width}w`;
+              }
+            } catch {}
             link.appendChild(img);
             if (item.badge || item.stock) {
               const meta = document.createElement('span');


### PR DESCRIPTION
## Summary
- add preconnect hint for marchingdogs image host to speed initial requests
- define width, height and srcset when rendering featured item images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c20ea9b54832c861c5cbb6e82a889