### PR TITLE
fix: optimize hero logo loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       <div class="section-content">
         <div class="card tilt reveal">
           <div id="package-anim" class="package-anim">
-            <img src="logo.png" alt="HecCollects logo" class="logo" loading="lazy">
+            <img src="logo.png" alt="HecCollects logo" class="logo" width="160" height="160" fetchpriority="high">
           </div>
           <h1>Welcome to HecCollects</h1>
           <p>Quality • Collectibles • Community. Scroll or use the menu to explore my marketplaces and story.</p>


### PR DESCRIPTION
## Summary
- remove lazy loading from hero logo and specify image dimensions
- request early hero logo fetch with `fetchpriority="high"`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689c20f2a834832c8d2be02803cc7b63