### PR TITLE
Respect reduced motion preferences

### DIFF
--- a/page-transitions.js
+++ b/page-transitions.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const body = document.body;
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
   const show = () => {
     body.classList.remove('fade-out');
@@ -15,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const sameHost = link.host === window.location.host;
     if (sameHost && target !== '_blank' && href && !href.startsWith('#')) {
       link.addEventListener('click', e => {
+        if (reducedMotion.matches) return;
         e.preventDefault();
         body.classList.remove('fade-in');
         body.classList.add('fade-out');

--- a/theme.css
+++ b/theme.css
@@ -6,10 +6,21 @@
 body {
   background: linear-gradient(to bottom, var(--bg-start), var(--bg-end));
   color: var(--white);
-  transition: background 0.4s ease-in-out, opacity 0.4s ease-in-out;
   opacity: 0;
   position: relative;
   z-index: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body {
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  body {
+    transition: background 0.4s ease-in-out, opacity 0.4s ease-in-out;
+  }
 }
 
 body::before {


### PR DESCRIPTION
## Summary
- Skip fade-out transitions when reduced motion is requested
- Apply transitions only when motion is not reduced via media queries
- Track reduced motion preference via `matchMedia` for up-to-date checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c20d2fb2c832cbaba2d945a7f83f8