### PR TITLE
chore: install Playwright before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "pretest": "playwright install",
     "test": "playwright test"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- install Playwright browsers prior to test runs via `pretest` script

## Testing
- `npm run pretest && npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689ca315978c832ca0ae4ee842a84776