### PR TITLE
docs: add font decoding build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 playwright-report/
 test-results/
+fonts/*.woff2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+All binary assets must be stored in text form (e.g., base64 `.b64` files) and decoded during build or deployment. Do **not** commit decoded binaries to the repository.
+
+Use the provided build scripts to decode assets before running tests or serving the site.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@
 
    This installs Playwright and downloads the necessary browser binaries.
 
-3. Run the test suite:
+3. Decode binary assets:
+
+   ```bash
+   node scripts/decode-font.js
+   ```
+
+   Fonts are stored in base64 form (`.b64`) and must be decoded before serving or testing.
+
+4. Run the test suite:
 
    ```bash
    npm test

--- a/scripts/decode-font.js
+++ b/scripts/decode-font.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = path.resolve(__dirname, '..', 'fonts', 'myfont.woff2.b64');
+const dest = path.resolve(__dirname, '..', 'fonts', 'myfont.woff2');
+
+const base64 = fs.readFileSync(src, 'utf8');
+const buffer = Buffer.from(base64, 'base64');
+fs.writeFileSync(dest, buffer);
+
+console.log(`Decoded ${dest}`);


### PR DESCRIPTION
## Summary
- add repository policy to store binary assets as base64 and decode during build
- add decode-font.js script and document running it before serving
- ignore decoded font artifacts

## Testing
- `node scripts/decode-font.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca67f22e8832c853d7cc7c04922cc