### PR TITLE
Add text-based HC logo

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" fill="#1e3c72"/>
+  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="90" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">HC</text>
+</svg>


### PR DESCRIPTION
## Summary
- add SVG `logo.svg` with 180x180 text-based HC design using primary colors

## Testing
- `python -m webbrowser logo.svg`
- `node scripts/decode-font.js`
- `npm test` *(fails: Host system missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689cab92ecb4832c87254ff96c60adc8