### PR TITLE
Add Apple touch icon links

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="apple-touch-icon" href="logo.svg">
   <title>FAQ - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <meta name="twitter:url" content="https://heccollects.github.io/" />
   <meta name="twitter:image" content="https://heccollects.github.io/logo.png" />
   <meta name="theme-color" content="#1e3c72" />
+  <link rel="apple-touch-icon" href="logo.svg">
   <title>HecCollects – Landing Page</title>
 
   <!-- Fonts and icons -->

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="apple-touch-icon" href="logo.svg">
   <title>Privacy Policy - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">

--- a/returns.html
+++ b/returns.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="apple-touch-icon" href="logo.svg">
   <title>Shipping & Returns - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">


### PR DESCRIPTION
## Summary
- add Apple touch icon references to site pages for better mobile homescreen integration

## Testing
- `node scripts/decode-font.js`
- `npm test` *(fails: missing host dependencies; 10 failed, 38 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_689cab96b170832c9994c7902646b9a9