### PR TITLE
Clean up apple touch icons and meta tags

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" href="logo.svg">
   <title>FAQ - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
- codex/create-tests-for-apple-touch-icon
-  <link rel="apple-touch-icon" href="logo.svg">
-  <link rel="apple-touch-icon" href="logo.png">
- main
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">

--- a/index.html
+++ b/index.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info." />
-  <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:" />
-  <meta property="og:title" content="HecCollects – Landing Page" />
-  <meta property="og:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
-  <meta property="og:url" content="https://heccollects.github.io/" />
-  <meta property="og:image" content="https://heccollects.github.io/logo.png" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="HecCollects – Landing Page" />
-  <meta name="twitter:description" content="Landing page for HecCollects featuring marketplace links and contact info." />
-  <meta name="twitter:url" content="https://heccollects.github.io/" />
-  <meta name="twitter:image" content="https://heccollects.github.io/logo.png" />
-  <meta name="theme-color" content="#1e3c72" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info.">
+  <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:">
+  <meta property="og:title" content="HecCollects – Landing Page">
+  <meta property="og:description" content="Landing page for HecCollects featuring marketplace links and contact info.">
+  <meta property="og:url" content="https://heccollects.github.io/">
+  <meta property="og:image" content="https://heccollects.github.io/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="HecCollects – Landing Page">
+  <meta name="twitter:description" content="Landing page for HecCollects featuring marketplace links and contact info.">
+  <meta name="twitter:url" content="https://heccollects.github.io/">
+  <meta name="twitter:image" content="https://heccollects.github.io/logo.png">
+  <meta name="theme-color" content="#1e3c72">
   <link rel="apple-touch-icon" href="logo.svg">
   <title>HecCollects – Landing Page</title>
 
@@ -35,12 +35,8 @@
       <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQfpCAwPIxrPrt21AAAHzklEQVRIx5VWW4xdZRVea/3/vpxz5lxmOtPOTB3aTjvTDnRaCnQsN7ECVZsAoharoHEiEmMCJkYT44MPRh4IDwrRqDGGWxEVgxmUGGipWgqhLVIY6I2Wobe5T885c2bP2fe1fNhnzpwJaMJ62Ttr/3vd1/996Hs+AAgAwkeLgIgAizScEgAkBET6X3/VRScPhAYPUlOJSMyiiSxLA5KIICIAJC8iHAZRxKwIEXGJ90WjgL7vL1FJYhpiZtPQWusgCE6NTR47P3ZupliedwGgkEmtalu2saujt7PdNI0oioIwUkS4mF5jBtKQjwAgsAgIpFP2dLnyzMEjfz381smxScfzWRaPEmLWtjasbL9zYPPu67e2FXKe5wtAzUmDTfQ9vx44ADALEZqG8dS/Xn9o6KUPpmZs07ANIwlQ6nkKxMxeGHpBuGZ564/u2HHPp7cFYcTMtLQv6Pv+YuwsWqkgjr//+LNPHDiUse2UaYAwsxACNQTGgCzIiITkhWHF9QY/NfCLwV2mUlEcEy22BOtTBCBEFMb89Ucfe+Houx2FnCFRJOAzIoAr5DLVi5wiThPnKAYERDQITxerO67cuOeBQUNRzEwLfUDP82v1F7Et877f7Nlz4FAu39yj517qOXnMTX1hpNdluqlp7vP58jwTAGQpfn62ZdhN/aTjYhpZABHk9+WVe8fD+27a+tvv3OP5AWKt5Tp5RMzplP3Yy6/ueeVweyFbDOL+bHU6MhTCOss76GRvzZe/3TkaRQoAtI4roo5W0/0ptxzrakw9tmeX/NZc4elXDm/r7R68+fqq62lFIEDJKlmGniyVH35+by5l+7EUVNSfdj8IrAqrgYwTC/lMwPT3YusLpWXA6MVEINfky6ORfq3a1FcoNhEHLLmU9dDQSxPFsm1oEQEAAoCYRWm958Dhs9OX0qaej/G6JmdHdjaNXFDRl5tLW9KORtlXarn/wqr7z6/eW2rNEFskf5laMRfpXst7aqxLoYiIbRrnZ4pP/vsQaR2zAAAJiFbk+8HQG8Mp02QWAMyouKCjFh2u0GFeRSuMMBTalnEsFANlIO1olOlI3zXSMxUa7Ub4jZGe152mJuIwlrRpDr3xtuf5WpGAEIuYhnFydOL0+JRt6ljERH5zPnPQySmECuv9lfw/5/IGMoH8sfvMn9acsZBFYD6mzenqjtzsesvbniuXY0UoLGKbxpnx6eMXx03TYBESAUA8MTrheL5CYgGL5H3fPjyfGfGtc4G5by7nMyqUtO1tzlauys1eYjUvFAh9tWXm4cmOnWfWf6m5SFgbdkKc9/1jF8cBUAR0or54qZTsMEtyTcI7burBVSNn3fTRaqbViIdmW8dDy40RACyCI9WMRRIJdhqhL0TJgqNAMrMAF2ZKyfDXblPH9RDBDUJNVA0jS+n3/PR3R9YXIx2AksjfNyH7jVbbMgDAD0JDorwVPltu25JyuszwD6W2KIq0JkWEgADgeF6yZzUHhlZeGG2/fN3whYmNn2h/b2J6dM79nZPTCJqrA2sv+9zm3n8cPf7mB2OAsPPyte3N+YOnzh6fLJ6oNDEASbyxIz89Vy051VzaBgCdZFXPoC2XjYPwhr61N/R1dzbn9w6f6lu5/NWT71/d3TVedrb1XPb8f46n7dS9t1zrh1E2nV6zfJkXxXdt2/TW2dHVbc2OF2zvX//W2Yua6OjZsRffPtmWz8LCJiMA9HQsB6VEQCtyg+j2azYp5K5lzeeLFce7lLKsC5fK1/Wu6V7R5gZhWz47Vpq9pX9DIWV2LSsEjM+9fnRi1pmrBp/ZuDZtmi++fXJ954qkLeh6nqnV9OzcwI8f3nxZx/HRye7ly2xDr2tvffnd0zu39B27OBFG8RcH+p87/E5Xa4EQz02XWprSk7PO5lUdB06MXN3d5YXheKmysjlvGbroVF87fe7Qgz/saM77UYS+58fCKdse/OXjT79ypL2Qc4MwFhERUys3CA2lAMALI0urBHMUkYAQYMRsah1EESISIotoRSWn+rUbtj75wKDreYpIw8L83n3jwNCRYUCwDI0IACgiVrp2pWQsU0QaUTfBLxaxDA0gCQAooiiK775x6yL2AQAheZ5/y6a+HZv6Sk5VETELM4tIzMwiXH9hYZZEk3wVEWZOlIRYnJu/uX/DZ6+83PN8Qqo5WABr+enu21qaMn4YUm3IPoYQoR/GhUz6Z7tvS1JMzFL9c9UPele2Pzq4yw3CmFl9HB9ExCzVIHhkcNeGrs6qH9SQOcEDEAABrajqend8csuv793tBmHS3gVc+n9iKOWF4bwf/OpbX7lz21V1qEm6sgD6NdisQdv+4RPfe+zP70/O5NMpUysWEBFpoC2IiAiEGMZcnndXt7U88s1dt265wnU9RdTIixaIVwOti5lTKXuqPPvzv738zGtvTM06plaWoTVRndnFzH4Y+VHcms3cde1VP7j91vaWQi32pVJjFcltWOc9ccxaK8Mwzk1ODx0Z3v/uqVPjUyWnGsZRUpN8OrWuvW37Fb13Dly5tnNFFEVhGKm69Y8gXo2ywO+YxTYNUoqZZ2Yr46VKxXVBIJuy2wu55YUcKcVx7AchElIjPW0wtTSDD0nihghNpUgpWdhA5jiIYmYhxEUq92H+u6RES6tUOy3188Ky+Csi4sL+LKHlH8rgvwr7YdbcutDpAAAAAElFTkSuQmCC">
     <script type="application/ld+json" src="schema.json" defer></script>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14'>🚀</text></svg>'">
- codex/create-tests-for-apple-touch-icon
-    <link rel="apple-touch-icon" href="logo.svg">
-    <link rel="apple-touch-icon" href="logo.png">
- main
-    <meta name="apple-mobile-web-app-capable" content="yes">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14'>🚀</text></svg>'">
+  <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="HecCollects">
   </head>

--- a/privacy.html
+++ b/privacy.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" href="logo.svg">
   <title>Privacy Policy - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
- codex/create-tests-for-apple-touch-icon
-  <link rel="apple-touch-icon" href="logo.svg">
-  <link rel="apple-touch-icon" href="logo.png">
- main
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">

--- a/returns.html
+++ b/returns.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" href="logo.svg">
   <title>Shipping & Returns - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
- codex/create-tests-for-apple-touch-icon
-  <link rel="apple-touch-icon" href="logo.svg">
-  <link rel="apple-touch-icon" href="logo.png">
- main
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">


### PR DESCRIPTION
## Summary
- Remove stray placeholder text and duplicate apple-touch-icon links
- Keep a single `logo.svg` apple-touch icon in each page
- Normalize meta tags to standard HTML formatting

## Testing
- `npm test` *(fails: Host system missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689cb4a92038832cb905a6f0725652b7