### PR TITLE
Add safe area inset support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info.">
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:">

--- a/style.css
+++ b/style.css
@@ -98,7 +98,7 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .scroll-cue{position:absolute;bottom:1.8rem;left:50%;transform:translateX(-50%);font-size:.8rem;opacity:.8;animation:cues 4s ease-in-out infinite;z-index:1}
 @keyframes cues{0%,100%{opacity:.2;transform:translate(-50%,0)}50%{opacity:1;transform:translate(-50%,6px)}}
 /* ---------- Navbar ---------- */
-.navbar{position:fixed;top:0;left:0;width:100%;padding:.7rem 1rem;display:flex;justify-content:space-between;align-items:center;background:rgba(0,0,0,.45);backdrop-filter:blur(6px);z-index:10000;box-shadow:0 4px 12px rgba(0,0,0,.3)}
+.navbar{position:fixed;top:0;left:0;width:100%;padding:calc(env(safe-area-inset-top)+.7rem) 1rem .7rem;display:flex;justify-content:space-between;align-items:center;background:rgba(0,0,0,.45);backdrop-filter:blur(6px);z-index:10000;box-shadow:0 4px 12px rgba(0,0,0,.3)}
 .brand{font-size:1.3rem;font-weight:700;text-decoration:none;color:inherit}
 .nav-toggle{width:32px;height:24px;display:flex;flex-direction:column;justify-content:space-between;background:none;border:none;cursor:pointer;z-index:10001}
 .line{width:100%;height:3px;background:var(--white);border-radius:2px;transition:transform .3s,opacity .3s}
@@ -152,7 +152,7 @@ section{background-attachment:fixed}
 75%{box-shadow:0 -2.6em 0 0 rgba(242,140,47,.2),1.8em -1.8em 0 0 rgba(242,140,47,.2),2.5em 0 0 0 rgba(242,140,47,.2),1.75em 1.75em 0 0 rgba(242,140,47,.2),0 2.5em 0 0 rgba(242,140,47,.5),-1.8em 1.8em 0 0 rgba(242,140,47,.7),-2.6em 0 0 0 var(--color-accent),-1.8em -1.8em 0 0 rgba(242,140,47,.2);}
 87.5%{box-shadow:0 -2.6em 0 0 rgba(242,140,47,.2),1.8em -1.8em 0 0 rgba(242,140,47,.2),2.5em 0 0 0 rgba(242,140,47,.2),1.75em 1.75em 0 0 rgba(242,140,47,.2),0 2.5em 0 0 rgba(242,140,47,.2),-1.8em 1.8em 0 0 rgba(242,140,47,.5),-2.6em 0 0 0 rgba(242,140,47,.7),-1.8em -1.8em 0 0 var(--color-accent);}
 }
-.cookie-banner{position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,.85);color:var(--white);padding:.6rem 1rem;font-size:.85rem;display:flex;justify-content:space-between;align-items:center;z-index:100000}
+.cookie-banner{position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,.85);color:var(--white);padding:.6rem 1rem calc(env(safe-area-inset-bottom)+.6rem);font-size:.85rem;display:flex;justify-content:space-between;align-items:center;z-index:100000}
 #cookie-btn{background:var(--color-accent);color:var(--white);border:none;border-radius:.3rem;padding:.3rem .7rem;cursor:pointer}
 @media (prefers-reduced-motion: reduce){
 *{


### PR DESCRIPTION
## Summary
- allow full-width viewport on notched devices
- pad navbar and cookie banner using safe-area insets

## Testing
- `npm test` *(fails: missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689d5015bb18832c95b9569e3cbacb31