### PR TITLE
Add webkit backdrop filter for nav menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -106,7 +106,7 @@ p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 .nav-toggle.open .line:nth-child(2){opacity:0}
 .nav-toggle.open .line:nth-child(3){transform:translateY(-9px) rotate(-45deg)}
 /* Overlay Menu (desktop & mobile) */
-.nav-menu{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;background:rgba(21,21,21,.85);backdrop-filter:blur(8px);box-shadow:0 0 0 100vmax rgba(0,0,0,.55);transform:translateY(-100%);pointer-events:none;opacity:0;transition:transform .45s cubic-bezier(.34,1.56,.64,1),opacity .3s;z-index:10001}
+.nav-menu{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;background:rgba(21,21,21,.85);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);box-shadow:0 0 0 100vmax rgba(0,0,0,.55);transform:translateY(-100%);pointer-events:none;opacity:0;transition:transform .45s cubic-bezier(.34,1.56,.64,1),opacity .3s;z-index:10001}
 .nav-menu.open{transform:translateY(0);pointer-events:auto;opacity:1}
 .nav-menu a{color:var(--white);font-size:1.8rem;font-weight:600;text-decoration:none;position:relative}
 .nav-menu a::after{content:"";position:absolute;left:0;bottom:-6px;width:0;height:2px;background:var(--color-accent);transition:width .3s}


### PR DESCRIPTION
## Summary
- ensure Safari renders the nav menu overlay blur by adding `-webkit-backdrop-filter`

## Testing
- `npm test -- tests/menu.spec.ts --project=mobile-iphone`
- `npm test -- tests/menu.spec.ts --config=tmp-webkit.config.ts --project=desktop-webkit`


------
https://chatgpt.com/codex/tasks/task_e_689d526f92bc832ca8600691747af720