### PR TITLE
Add WebGL fallback for unsupported browsers

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@
   }
 
   const canHover = window.matchMedia('(hover: hover)').matches;
+  const webglSupported = !!window.WebGLRenderingContext;
 
   const initListClones = () => {
     if (window.__listClonesInitialized) return;
@@ -434,7 +435,7 @@
     let vantaEffect;
 
     const initVanta = () => {
-      if (!heroSection || motionQuery.matches || !window.VANTA) return;
+      if (!heroSection || motionQuery.matches || !window.VANTA || !webglSupported) return;
       vantaEffect = window.VANTA.NET({
         el: heroSection,
         mouseControls: false,
@@ -497,10 +498,10 @@
 
   // Package reveal animation
   const packageContainer = document.getElementById('package-anim');
-  if (packageContainer && window.THREE) {
+  if (packageContainer) {
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const isLocal = window.location.protocol === 'file:';
-    if (reduced || isLocal) {
+    if (!webglSupported || !window.THREE || reduced || isLocal) {
       packageContainer.classList.add('show-logo');
     } else {
       let renderer, scene, camera, lid, logoMesh, animId, startTime, progress = 0;

--- a/tests/webgl-logo.spec.ts
+++ b/tests/webgl-logo.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+test('static logo is shown when WebGL is unavailable', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, 'WebGLRenderingContext', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  await page.goto('file://' + filePath);
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      throw new Error(msg.text());
+    }
+  });
+
+  await expect(page.locator('#package-anim')).toHaveClass(/show-logo/);
+  await expect(page.locator('#package-anim canvas')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- detect WebGL support before starting Three.js effects
- show static logo when WebGL isn't available
- add Playwright test covering WebGL fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d5cfbbc04832ca6c1c7e003bcb527