### PR TITLE
Improve policy pages with sections, legal clauses and styling

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -11,24 +11,25 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
 </head>
-<body>
-  <main class="privacy-content">
+<body class="faq-page">
+  <main class="faq-content">
     <h1>Frequently Asked Questions</h1>
     <section>
-      <h2>Shipping</h2>
-      <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier.</p>
+      <h2>Orders & Shipping</h2>
+      <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>
     </section>
     <section>
-      <h2>Returns</h2>
-      <p>Returns are accepted within 30 days of delivery. Items must be returned in original condition for a full refund.</p>
+      <h2>Returns & Refunds</h2>
+      <p>Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method once items are received.</p>
     </section>
     <section>
-      <h2>Communication</h2>
-      <p>I respond to all messages within 24 hours. Feel free to reach out for any questions or special requests.</p>
+      <h2>Customer Support</h2>
+      <p>I respond to all messages within 24 hours. You have the right to prompt assistance with any order issue.</p>
     </section>
   </main>
   <footer class="site-footer">
     <a href="index.html">Home</a>
+    <a href="faq.html">FAQ</a>
     <a href="returns.html">Returns</a>
     <a href="privacy.html">Privacy Policy</a>
   </footer>
@@ -42,7 +43,7 @@
         "name": "How long does shipping take?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Orders are packed within 2 business days and typically arrive within 3-5 business days."
+          "text": "Orders are packed within 2 business days and typically arrive within 3-5 business days, depending on the carrier and destination."
         }
       },
       {
@@ -50,7 +51,7 @@
         "name": "What is your return policy?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Returns are accepted within 30 days of delivery if items are in original condition."
+          "text": "Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method."
         }
       },
       {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "pretest": "node scripts/decode-font.js && node scripts/decode-logo.js && node scripts/decode-snapshots.js && playwright install",
+    "pretest": "node scripts/decode-font.js && node scripts/decode-logo.js && node scripts/decode-snapshots.js && playwright install --with-deps",
     "test": "playwright test"
   },
   "keywords": [],

--- a/privacy.html
+++ b/privacy.html
@@ -11,12 +11,25 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
 </head>
-<body>
-  <main class="privacy-content">
+<body class="privacy-page">
+  <main class="policy-content">
     <h1>Privacy Policy</h1>
-    <p>We value your privacy. Any information submitted through this site is used solely to communicate updates and offers from HecCollects.</p>
-    <p>We use analytics to understand how visitors interact with the site. This helps improve content and user experience. Cookies may be stored on your device for this purpose.</p>
-    <p>Your data will never be sold to third parties. For questions about this policy, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
+    <section>
+      <h2>Information We Collect</h2>
+      <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>
+    </section>
+    <section>
+      <h2>How We Use Information</h2>
+      <p>Information is used to send updates, respond to inquiries, and enhance site performance. Cookies may be stored on your device to support these functions, and we do not sell or share your information with third parties except as required by law.</p>
+    </section>
+    <section>
+      <h2>Data Retention</h2>
+      <p>Personal data is retained only for as long as necessary to fulfill the purposes outlined in this policy or to comply with legal obligations. You may request deletion of your data at any time.</p>
+    </section>
+    <section>
+      <h2>Your Rights</h2>
+      <p>You have the right to access, correct, or erase your personal information. To exercise these rights or ask questions, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
+    </section>
   </main>
   <footer class="site-footer">
     <a href="index.html">Home</a>

--- a/returns.html
+++ b/returns.html
@@ -11,16 +11,24 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
 </head>
-<body>
-  <main class="privacy-content">
+<body class="returns-page">
+  <main class="policy-content">
     <h1>Shipping & Returns</h1>
     <section>
       <h2>Shipping Policy</h2>
-      <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available.</p>
+      <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>
     </section>
     <section>
       <h2>Returns Policy</h2>
-      <p>Returns are accepted within 30 days of delivery. Items should be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
+      <p>Returns are accepted within 30 days of delivery. Items must be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
+    </section>
+    <section>
+      <h2>Refund Exceptions</h2>
+      <p>Custom or personalized orders and digital items are non-refundable unless defective. Shipping costs are non-refundable once an order has shipped.</p>
+    </section>
+    <section>
+      <h2>Customer Rights</h2>
+      <p>You may request an exchange or refund for eligible items. If a dispute arises, you have the right to seek resolution through your payment provider or applicable consumer protection laws.</p>
     </section>
     <section>
       <h2>Communication Expectations</h2>
@@ -30,6 +38,7 @@
   <footer class="site-footer">
     <a href="index.html">Home</a>
     <a href="faq.html">FAQ</a>
+    <a href="returns.html">Returns</a>
     <a href="privacy.html">Privacy Policy</a>
   </footer>
   <script src="page-transitions.js" defer></script>

--- a/theme.css
+++ b/theme.css
@@ -40,3 +40,19 @@ body.fade-in {
 body.fade-out {
   opacity: 0;
 }
+
+/* Page-specific theme overrides */
+body.privacy-page {
+  --bg-start: #0b3d91;
+  --bg-end: #1e90ff;
+}
+
+body.returns-page {
+  --bg-start: #5e2e2e;
+  --bg-end: #b34747;
+}
+
+body.faq-page {
+  --bg-start: #005f73;
+  --bg-end: #0a9396;
+}


### PR DESCRIPTION
## Summary
- Add detailed sections for data use, retention and rights on privacy page
- Expand shipping and returns page with refund exceptions and customer rights
- Refresh FAQ with clearer questions and include page-specific theming for all policy pages
- Ensure Playwright tests install needed system dependencies before running

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de550dbdc832c816efc6a32b003a5