### PR TITLE
Add accessible navigation to policy pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -12,6 +12,12 @@
   <meta name="apple-mobile-web-app-title" content="HecCollects">
 </head>
 <body class="faq-page">
+  <nav class="page-nav" aria-label="Page navigation">
+    <a href="index.html">Home</a>
+    <a href="faq.html" aria-current="page">FAQ</a>
+    <a href="returns.html">Returns</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </nav>
   <main class="faq-content">
     <h1>Frequently Asked Questions</h1>
     <section>

--- a/privacy.html
+++ b/privacy.html
@@ -12,6 +12,12 @@
   <meta name="apple-mobile-web-app-title" content="HecCollects">
 </head>
 <body class="privacy-page">
+  <nav class="page-nav" aria-label="Page navigation">
+    <a href="index.html">Home</a>
+    <a href="faq.html">FAQ</a>
+    <a href="returns.html">Returns</a>
+    <a href="privacy.html" aria-current="page">Privacy Policy</a>
+  </nav>
   <main class="policy-content">
     <h1>Privacy Policy</h1>
     <section>

--- a/returns.html
+++ b/returns.html
@@ -12,6 +12,12 @@
   <meta name="apple-mobile-web-app-title" content="HecCollects">
 </head>
 <body class="returns-page">
+  <nav class="page-nav" aria-label="Page navigation">
+    <a href="index.html">Home</a>
+    <a href="faq.html">FAQ</a>
+    <a href="returns.html" aria-current="page">Returns</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </nav>
   <main class="policy-content">
     <h1>Shipping & Returns</h1>
     <section>

--- a/style.css
+++ b/style.css
@@ -201,3 +201,7 @@ main
 .site-footer{padding:1rem;text-align:center;color:var(--white);}
 .site-footer a{color:var(--color-accent);margin:0 .5rem;text-decoration:none;}
 .site-footer a:hover{text-decoration:underline;}
+
+.page-nav{padding:1rem;text-align:center;}
+.page-nav a{color:var(--color-accent);margin:0 .5rem;text-decoration:none;}
+.page-nav a[aria-current="page"]{font-weight:600;text-decoration:underline;}


### PR DESCRIPTION
## Summary
- add top navigation to FAQ, Returns, and Privacy pages
- mark current page using `aria-current="page"`
- style nav links to highlight active page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689deee3b044832c9795d52d5ac77680