### PR TITLE
Clean logo SVG and decode during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Decode logo assets
+        run: node scripts/decode-logo.js
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/logo.svg
+++ b/logo.svg
@@ -4,15 +4,10 @@
       <stop offset="0%" stop-color="#1e3c72"/>
       <stop offset="100%" stop-color="#2a5298"/>
     </linearGradient>
- codex/find-or-create-high-quality-logo-zzibxp
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
       <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000" flood-opacity="0.3"/>
     </filter>
   </defs>
   <rect width="160" height="160" rx="32" ry="32" fill="url(#grad)"/>
   <text x="50%" y="50%" font-family="'Poppins', Arial, sans-serif" font-size="72" font-weight="700" fill="#ffffff" stroke="#f28c2f" stroke-width="2" stroke-linejoin="round" paint-order="stroke" text-anchor="middle" dominant-baseline="central" filter="url(#shadow)">HC</text>
-  </defs>
-  <rect width="160" height="160" rx="32" ry="32" fill="url(#grad)"/>
-  <text x="50%" y="50%" font-family="'Poppins', Arial, sans-serif" font-size="72" font-weight="700" fill="#ffffff" text-anchor="middle" dominant-baseline="central">HC</text>
- main
 </svg>


### PR DESCRIPTION
## Summary
- Simplify `logo.svg` by removing stray text and duplicate elements
- Add GitHub Pages workflow that decodes logo assets during build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4872612c832cb226f7a33ab9c041