### PR TITLE
Handle texture load error with static logo

### DIFF
--- a/main.js
+++ b/main.js
@@ -537,7 +537,13 @@
         scene.add(lid);
         const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
         scene.add(light);
-        const tex = new THREE.TextureLoader().load('logo.png');
+        const loader = new THREE.TextureLoader();
+        const tex = loader.load('logo.png', undefined, undefined, () => {
+          packageContainer.classList.add('show-logo');
+          if (renderer && renderer.domElement) {
+            renderer.domElement.remove();
+          }
+        });
         const plane = new THREE.PlaneGeometry(1.2, 1.2);
         const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
         logoMesh = new THREE.Mesh(plane, mat);

--- a/style.css
+++ b/style.css
@@ -171,7 +171,7 @@ transition: none !important;
 .package-anim{position:relative;width:200px;height:200px;margin:0 auto 1rem}
 .package-anim canvas{width:100%;height:100%}
 .package-anim .logo{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;opacity:0;transition:opacity .5s}
-.package-anim.show-logo .logo{opacity:1}
+.package-anim.show-logo .logo{opacity:1;content:url('logo.svg')}
 
 /* Background feature marquee */
 .feature-marquee-container{position:absolute;inset:0;z-index:-1;pointer-events:none;overflow:hidden}

--- a/tests/texture-fallback.spec.ts
+++ b/tests/texture-fallback.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+test('static logo is shown when texture fails to load', async ({ page }) => {
+  await page.route('**/logo.png', route => route.abort());
+
+  await page.goto('file://' + filePath);
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      throw new Error(msg.text());
+    }
+  });
+
+  await expect(page.locator('#package-anim')).toHaveClass(/show-logo/);
+  await expect(page.locator('#package-anim canvas')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- show static logo when texture loader fails and remove canvas
- use CSS to swap in SVG logo when static logo is shown
- test texture load failure gracefully falls back to static logo

## Testing
- `npx playwright test tests/texture-fallback.spec.ts`
- `npm test` *(fails: GA script loads, navbar layout snapshot, preloader ripple)*

------
https://chatgpt.com/codex/tasks/task_e_68a00bd4700c832cb5c30eee7557ddab