### PR TITLE
Expand FAQ categories and schema markup

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -40,17 +40,32 @@
   </header>
   <main class="faq-content">
     <h1>Frequently Asked Questions</h1>
-    <section>
+    <ul>
+      <li><a href="#orders-shipping">Orders & Shipping</a></li>
+      <li><a href="#returns-refunds">Returns & Refunds</a></li>
+      <li><a href="#customer-support">Customer Support</a></li>
+      <li><a href="#payments-pricing">Payments & Pricing</a></li>
+      <li><a href="#product-information">Product Information</a></li>
+    </ul>
+    <section id="orders-shipping">
       <h2>Orders & Shipping</h2>
       <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>
     </section>
-    <section>
+    <section id="returns-refunds">
       <h2>Returns & Refunds</h2>
       <p>Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method once items are received.</p>
     </section>
-    <section>
+    <section id="customer-support">
       <h2>Customer Support</h2>
       <p>I respond to all messages within 24 hours. You have the right to prompt assistance with any order issue.</p>
+    </section>
+    <section id="payments-pricing">
+      <h2>Payments & Pricing</h2>
+      <p>Payments are processed securely, and pricing reflects any applicable taxes or fees. Accepted methods include major credit cards and PayPal.</p>
+    </section>
+    <section id="product-information">
+      <h2>Product Information</h2>
+      <p>All items are described accurately with detailed photos. Contact me for any additional information about condition or provenance.</p>
     </section>
   </main>
   <footer class="site-footer">
@@ -86,6 +101,22 @@
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "I aim to respond to all inquiries within 24 hours."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which payment methods do you accept?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Payments are processed securely and I accept major credit cards and PayPal."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do you describe item condition?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Each listing includes detailed photos and descriptions so you know the exact condition of the item."
         }
       }
     ]


### PR DESCRIPTION
## Summary
- add navigation list linking to FAQ categories
- include Payments & Pricing and Product Information sections
- extend JSON-LD FAQPage schema with new questions

## Testing
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `npm test` *(fails: GA script loads, navbar layout snapshot, preloader ripple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a018555744832ca5359263247b75cc