### PR TITLE
Use accessible details for FAQ and policy sections

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -47,26 +47,26 @@
       <li><a href="#payments-pricing">Payments & Pricing</a></li>
       <li><a href="#product-information">Product Information</a></li>
     </ul>
-    <section id="orders-shipping">
-      <h2>Orders & Shipping</h2>
+    <details id="orders-shipping">
+      <summary aria-expanded="false">Orders & Shipping</summary>
       <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>
-    </section>
-    <section id="returns-refunds">
-      <h2>Returns & Refunds</h2>
+    </details>
+    <details id="returns-refunds">
+      <summary aria-expanded="false">Returns & Refunds</summary>
       <p>Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method once items are received.</p>
-    </section>
-    <section id="customer-support">
-      <h2>Customer Support</h2>
+    </details>
+    <details id="customer-support">
+      <summary aria-expanded="false">Customer Support</summary>
       <p>I respond to all messages within 24 hours. You have the right to prompt assistance with any order issue.</p>
-    </section>
-    <section id="payments-pricing">
-      <h2>Payments & Pricing</h2>
+    </details>
+    <details id="payments-pricing">
+      <summary aria-expanded="false">Payments & Pricing</summary>
       <p>Payments are processed securely, and pricing reflects any applicable taxes or fees. Accepted methods include major credit cards and PayPal.</p>
-    </section>
-    <section id="product-information">
-      <h2>Product Information</h2>
+    </details>
+    <details id="product-information">
+      <summary aria-expanded="false">Product Information</summary>
       <p>All items are described accurately with detailed photos. Contact me for any additional information about condition or provenance.</p>
-    </section>
+    </details>
   </main>
   <footer class="site-footer">
     <a href="index.html">Home</a>

--- a/main.js
+++ b/main.js
@@ -25,6 +25,15 @@
     }
   }
 
+  document.querySelectorAll('details').forEach(d => {
+    const summary = d.querySelector('summary');
+    if (!summary) return;
+    summary.setAttribute('aria-expanded', d.open ? 'true' : 'false');
+    d.addEventListener('toggle', () => {
+      summary.setAttribute('aria-expanded', d.open ? 'true' : 'false');
+    });
+  });
+
   const canHover = window.matchMedia('(hover: hover)').matches;
   const webglSupported = !!window.WebGLRenderingContext;
 

--- a/privacy.html
+++ b/privacy.html
@@ -40,22 +40,22 @@
   </header>
   <main class="policy-content">
     <h1>Privacy Policy</h1>
-    <section>
-      <h2>Information We Collect</h2>
+    <details>
+      <summary aria-expanded="false">Information We Collect</summary>
       <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>
-    </section>
-    <section>
-      <h2>How We Use Information</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">How We Use Information</summary>
       <p>Information is used to send updates, respond to inquiries, and enhance site performance. Cookies may be stored on your device to support these functions, and we do not sell or share your information with third parties except as required by law.</p>
-    </section>
-    <section>
-      <h2>Data Retention</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">Data Retention</summary>
       <p>Personal data is retained only for as long as necessary to fulfill the purposes outlined in this policy or to comply with legal obligations. You may request deletion of your data at any time.</p>
-    </section>
-    <section>
-      <h2>Your Rights</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">Your Rights</summary>
       <p>You have the right to access, correct, or erase your personal information. To exercise these rights or ask questions, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
-    </section>
+    </details>
   </main>
   <footer class="site-footer">
     <a href="index.html">Home</a>

--- a/returns.html
+++ b/returns.html
@@ -40,26 +40,26 @@
   </header>
   <main class="policy-content">
     <h1>Shipping & Returns</h1>
-    <section>
-      <h2>Shipping Policy</h2>
+    <details>
+      <summary aria-expanded="false">Shipping Policy</summary>
       <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>
-    </section>
-    <section>
-      <h2>Returns Policy</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">Returns Policy</summary>
       <p>Returns are accepted within 30 days of delivery. Items must be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
-    </section>
-    <section>
-      <h2>Refund Exceptions</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">Refund Exceptions</summary>
       <p>Custom or personalized orders and digital items are non-refundable unless defective. Shipping costs are non-refundable once an order has shipped.</p>
-    </section>
-    <section>
-      <h2>Customer Rights</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">Customer Rights</summary>
       <p>You may request an exchange or refund for eligible items. If a dispute arises, you have the right to seek resolution through your payment provider or applicable consumer protection laws.</p>
-    </section>
-    <section>
-      <h2>Communication Expectations</h2>
+    </details>
+    <details>
+      <summary aria-expanded="false">Communication Expectations</summary>
       <p>I strive to answer all messages within 24 hours. Reach out with any order questions and I'll work to make things right.</p>
-    </section>
+    </details>
   </main>
   <footer class="site-footer">
     <a href="index.html">Home</a>

--- a/style.css
+++ b/style.css
@@ -35,6 +35,10 @@ section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z
 h1{font-size:2.4rem;text-shadow:0 3px 8px rgba(0,0,0,.4)}
 h2{font-size:1.9rem;color:var(--color-accent)}
 p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
+details{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.08)}
+summary{cursor:pointer;font-size:1.2rem;font-weight:600;color:var(--color-accent);list-style:none}
+summary::-webkit-details-marker{display:none}
+summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 /* ---------- Buttons ---------- */
 .links{display:flex;flex-direction:column;gap:1rem;width:100%}
 .btn{display:flex;align-items:center;justify-content:center;gap:.6rem;width:100%;padding:.85rem 1.3rem;font-size:1rem;font-weight:600;color:var(--white);background:var(--color-primary);border:none;border-radius:1rem;text-decoration:none;transition:.25s;position:relative;overflow:hidden;cursor:pointer}


### PR DESCRIPTION
## Summary
- Replace FAQ and policy `<section>` blocks with `<details>`/`<summary>` pairs for clearer question-and-answer structure.
- Style new collapsible elements to match site theme.
- Manage `aria-expanded` states via script for improved accessibility.

## Testing
- `npm test` *(fails: 3 failed, 2 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a01a85c24c832cabb9dc481ec40324