### PR TITLE
Add responsive table of contents to pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -40,13 +40,15 @@
   </header>
   <main class="faq-content">
     <h1>Frequently Asked Questions</h1>
-    <ul>
-      <li><a href="#orders-shipping">Orders & Shipping</a></li>
-      <li><a href="#returns-refunds">Returns & Refunds</a></li>
-      <li><a href="#customer-support">Customer Support</a></li>
-      <li><a href="#payments-pricing">Payments & Pricing</a></li>
-      <li><a href="#product-information">Product Information</a></li>
-    </ul>
+    <nav class="toc">
+      <ol>
+        <li><a href="#orders-shipping">Orders &amp; Shipping</a></li>
+        <li><a href="#returns-refunds">Returns &amp; Refunds</a></li>
+        <li><a href="#customer-support">Customer Support</a></li>
+        <li><a href="#payments-pricing">Payments &amp; Pricing</a></li>
+        <li><a href="#product-information">Product Information</a></li>
+      </ol>
+    </nav>
     <details id="orders-shipping">
       <summary aria-expanded="false">Orders & Shipping</summary>
       <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,17 @@
 
   <!-- Sections -->
   <main>
+    <nav class="toc">
+      <ol>
+        <li><a href="#welcome-to-heccollects">Welcome to HecCollects</a></li>
+        <li><a href="#shop-on-ebay">Shop on eBay</a></li>
+        <li><a href="#local-deals-on-offerup">Local Deals on OfferUp</a></li>
+        <li><a href="#about-heccollects">About HecCollects</a></li>
+        <li><a href="#testimonials">Testimonials</a></li>
+        <li><a href="#get-updates">Get Updates</a></li>
+        <li><a href="#business-inquiries">Business Inquiries</a></li>
+      </ol>
+    </nav>
     <!-- HOME -->
     <section id="home">
       <div class="section-content">
@@ -85,7 +96,7 @@
           <div id="package-anim" class="package-anim">
             <img src="logo.png" alt="HecCollects logo" class="logo" width="160" height="160" fetchpriority="high">
           </div>
-          <h1>Welcome to HecCollects</h1>
+          <h1 id="welcome-to-heccollects">Welcome to HecCollects</h1>
           <p>Quality • Collectibles • Community. Scroll or use the menu to explore my marketplaces and story.</p>
           <div class="links">
             <a href="#ebay" class="btn border-fade"><i class="fa-brands fa-ebay"></i> Browse eBay Deals</a>
@@ -105,7 +116,7 @@
     <section id="ebay">
       <div class="section-content">
         <div class="card reveal">
-          <h2>Shop on eBay</h2>
+          <h2 id="shop-on-ebay">Shop on eBay</h2>
           <p>Browse curated listings, graded cards, and exclusive bundles at competitive prices.</p>
           <div class="links">
             <a href="https://ebay.us/m/HoUY1I" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay"><i class="fa-brands fa-ebay"></i> Visit eBay Store</a>
@@ -127,7 +138,7 @@
     <section id="offerup">
       <div class="section-content">
         <div class="card reveal">
-          <h2>Local Deals on OfferUp</h2>
+          <h2 id="local-deals-on-offerup">Local Deals on OfferUp</h2>
           <p>Prefer local pickup? Check out my OfferUp inventory for quick deals and meet‑ups in SoCal.</p>
           <div class="links">
             <a href="https://offerup.co/xluJorjDIVb" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup"><i class="fa-solid fa-store"></i> Visit OfferUp</a>
@@ -148,7 +159,7 @@
     <section id="about">
       <div class="section-content">
         <div class="card reveal">
-          <h2>About HecCollects</h2>
+          <h2 id="about-heccollects">About HecCollects</h2>
             <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and how they compare within their respective hobbies. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
             <div class="trust-badges">
               <span class="badge"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Secure Transactions</span>
@@ -203,7 +214,7 @@
     <section id="subscribe">
       <div class="section-content">
         <div class="card reveal">
-          <h2>Get Updates</h2>
+          <h2 id="get-updates">Get Updates</h2>
           <p>Join the mailing list for new drops and exclusive deals.</p>
           <p class="incentive">Subscribers get early access and exclusive discounts.</p>
           <form action="https://formspree.io/f/mzzdeork" method="POST" class="subscribe-form">
@@ -226,7 +237,7 @@
     <section id="contact">
       <div class="section-content">
         <div class="card reveal">
-          <h2>Business Inquiries</h2>
+          <h2 id="business-inquiries">Business Inquiries</h2>
           <p>Have a question, bulk lot, or collaboration idea? Reach out and I’ll get back within 24 hours.</p>
           <div class="links">
             <a href="mailto:hectorsandoval1402@gmail.com" class="btn border-fade" data-analytics="email"><i class="fa-solid fa-envelope"></i> Email Me</a>

--- a/privacy.html
+++ b/privacy.html
@@ -14,46 +14,46 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "PrivacyPolicy",
-      "name": "HecCollects Privacy Policy",
-      "url": "https://heccollects.github.io/privacy.html",
-      "hasPart": [
-        {
-          "@type": "WebPageElement",
-          "name": "Cookie Usage",
-          "url": "https://heccollects.github.io/privacy.html#cookies"
-        },
-        {
-          "@type": "WebPageElement",
-          "name": "Analytics Tools",
-          "url": "https://heccollects.github.io/privacy.html#analytics"
-        },
-        {
-          "@type": "WebPageElement",
-          "name": "Data Sharing",
-          "url": "https://heccollects.github.io/privacy.html#data-sharing"
-        },
-        {
-          "@type": "WebPageElement",
-          "name": "Opt-Out Options",
-          "url": "https://heccollects.github.io/privacy.html#opt-out"
-        },
-        {
-          "@type": "WebPageElement",
-          "name": "Data Retention",
-          "url": "https://heccollects.github.io/privacy.html#data-retention"
-        },
-        {
-          "@type": "WebPageElement",
-          "name": "Your Rights and Data Requests",
-          "url": "https://heccollects.github.io/privacy.html#rights"
-        }
-      ]
-    }
-  </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "PrivacyPolicy",
+        "name": "HecCollects Privacy Policy",
+        "url": "https://heccollects.github.io/privacy.html",
+        "hasPart": [
+          {
+            "@type": "WebPageElement",
+            "name": "Cookie Usage",
+            "url": "https://heccollects.github.io/privacy.html#cookie-usage"
+          },
+          {
+            "@type": "WebPageElement",
+            "name": "Analytics Tools",
+            "url": "https://heccollects.github.io/privacy.html#analytics-tools"
+          },
+          {
+            "@type": "WebPageElement",
+            "name": "Data Sharing",
+            "url": "https://heccollects.github.io/privacy.html#data-sharing"
+          },
+          {
+            "@type": "WebPageElement",
+            "name": "Opt-Out Options",
+            "url": "https://heccollects.github.io/privacy.html#opt-out-options"
+          },
+          {
+            "@type": "WebPageElement",
+            "name": "Data Retention",
+            "url": "https://heccollects.github.io/privacy.html#data-retention"
+          },
+          {
+            "@type": "WebPageElement",
+            "name": "Your Rights and Data Requests",
+            "url": "https://heccollects.github.io/privacy.html#your-rights-and-data-requests"
+          }
+        ]
+      }
+    </script>
 </head>
 <body class="privacy-page">
   <header class="navbar">
@@ -80,19 +80,31 @@
   </header>
   <main class="policy-content">
     <h1>Privacy Policy</h1>
-    <details>
+    <nav class="toc">
+      <ol>
+        <li><a href="#information-we-collect">Information We Collect</a></li>
+        <li><a href="#how-we-use-information">How We Use Information</a></li>
+        <li><a href="#cookie-usage">Cookie Usage</a></li>
+        <li><a href="#analytics-tools">Analytics Tools</a></li>
+        <li><a href="#data-sharing">Data Sharing</a></li>
+        <li><a href="#opt-out-options">Opt-Out Options</a></li>
+        <li><a href="#data-retention">Data Retention</a></li>
+        <li><a href="#your-rights-and-data-requests">Your Rights and Data Requests</a></li>
+      </ol>
+    </nav>
+    <details id="information-we-collect">
       <summary aria-expanded="false">Information We Collect</summary>
       <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>
     </details>
-    <details>
+    <details id="how-we-use-information">
       <summary aria-expanded="false">How We Use Information</summary>
       <p>Information is used to send updates, respond to inquiries, and enhance site performance. Cookies may be stored on your device to support these functions, and we do not sell or share your information with third parties except as required by law.</p>
     </details>
-    <details id="cookies">
+    <details id="cookie-usage">
       <summary aria-expanded="false">Cookie Usage</summary>
       <p>We use essential and analytics cookies to remember your preferences and understand site traffic. You can control cookies through your browser settings.</p>
     </details>
-    <details id="analytics">
+    <details id="analytics-tools">
       <summary aria-expanded="false">Analytics Tools</summary>
       <p>We use privacy-focused analytics tools to measure visits and performance. These tools collect aggregated data and store it for up to 24 months.</p>
     </details>
@@ -100,7 +112,7 @@
       <summary aria-expanded="false">Data Sharing</summary>
       <p>Personal information is not sold. Data may be shared with service providers that help operate the site or as required by law.</p>
     </details>
-    <details id="opt-out">
+    <details id="opt-out-options">
       <summary aria-expanded="false">Opt-Out Options</summary>
       <p>You can opt out of analytics by blocking cookies or using browser extensions. To stop receiving emails or remove your information, use unsubscribe links or contact us.</p>
     </details>
@@ -108,7 +120,7 @@
       <summary aria-expanded="false">Data Retention</summary>
       <p>Mailing list data is kept until you unsubscribe or request deletion. Aggregated analytics data is retained for up to 24 months to help improve the site.</p>
     </details>
-    <details id="rights">
+    <details id="your-rights-and-data-requests">
       <summary aria-expanded="false">Your Rights and Data Requests</summary>
       <p>You have the right to access, correct, or erase your personal information. For data requests or questions, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
     </details>

--- a/returns.html
+++ b/returns.html
@@ -39,32 +39,48 @@
     </button>
   </header>
   <main class="policy-content">
-    <h1>Shipping & Returns</h1>
-    <details>
+    <h1>Shipping &amp; Returns</h1>
+    <nav class="toc">
+      <ol>
+        <li><a href="#shipping-policy">Shipping Policy</a></li>
+        <li>
+          <a href="#returns-policy">Returns Policy</a>
+          <ol>
+            <li><a href="#initiating-a-return">Initiating a Return</a></li>
+            <li><a href="#packaging-expectations">Packaging Expectations</a></li>
+            <li><a href="#refund-timeline">Refund Timeline</a></li>
+          </ol>
+        </li>
+        <li><a href="#refund-exceptions">Refund Exceptions</a></li>
+        <li><a href="#customer-rights">Customer Rights</a></li>
+        <li><a href="#communication-expectations">Communication Expectations</a></li>
+      </ol>
+    </nav>
+    <details id="shipping-policy">
       <summary aria-expanded="false">Shipping Policy</summary>
       <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>
       <p>For common questions about delivery, see the <a href="faq.html#orders-shipping">Orders &amp; Shipping FAQ</a>.</p>
     </details>
-    <details>
+    <details id="returns-policy">
       <summary aria-expanded="false">Returns Policy</summary>
       <p>Returns are accepted within 30 days of delivery. Items must be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
-      <h2>Initiating a Return</h2>
+      <h2 id="initiating-a-return">Initiating a Return</h2>
       <p>To start a return, reach out via the <a href="index.html#contact">contact form</a> with your order details. I will provide instructions within 24 hours.</p>
-      <h2>Packaging Expectations</h2>
+      <h2 id="packaging-expectations">Packaging Expectations</h2>
       <p>Securely repackage items to prevent damage in transit and include all original accessories or documentation.</p>
-      <h2>Refund Timeline</h2>
+      <h2 id="refund-timeline">Refund Timeline</h2>
       <p>Refunds are issued to the original payment method within 2 business days after the item is received and inspected.</p>
       <p>Additional details are available in the <a href="faq.html#returns-refunds">Returns &amp; Refunds FAQ</a>.</p>
     </details>
-    <details>
+    <details id="refund-exceptions">
       <summary aria-expanded="false">Refund Exceptions</summary>
       <p>Custom or personalized orders and digital items are non-refundable unless defective. Shipping costs are non-refundable once an order has shipped.</p>
     </details>
-    <details>
+    <details id="customer-rights">
       <summary aria-expanded="false">Customer Rights</summary>
       <p>You may request an exchange or refund for eligible items. If a dispute arises, you have the right to seek resolution through your payment provider or applicable consumer protection laws.</p>
     </details>
-    <details>
+    <details id="communication-expectations">
       <summary aria-expanded="false">Communication Expectations</summary>
       <p>I strive to answer all messages within 24 hours. Reach out with any order questions and I'll work to make things right.</p>
     </details>

--- a/style.css
+++ b/style.css
@@ -39,6 +39,12 @@ details{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border
 summary{cursor:pointer;font-size:1.2rem;font-weight:600;color:var(--color-accent);list-style:none}
 summary::-webkit-details-marker{display:none}
 summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
+/* ---------- Table of Contents ---------- */
+.toc{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.08);text-align:left}
+.toc>ol{list-style:none;padding-left:0;display:flex;flex-direction:column;gap:.5rem}
+.toc ol ol{padding-left:1rem}
+.toc a{text-decoration:none;color:var(--color-accent);font-weight:600}
+@media(min-width:768px){.toc>ol{flex-direction:row;flex-wrap:wrap}}
 /* ---------- Buttons ---------- */
 .links{display:flex;flex-direction:column;gap:1rem;width:100%}
 .btn{display:flex;align-items:center;justify-content:center;gap:.6rem;width:100%;padding:.85rem 1.3rem;font-size:1rem;font-weight:600;color:var(--white);background:var(--color-primary);border:none;border-radius:1rem;text-decoration:none;transition:.25s;position:relative;overflow:hidden;cursor:pointer}


### PR DESCRIPTION
## Summary
- Inserted navigation-based table of contents at the start of each main page
- Assigned unique anchor IDs to all major sections
- Styled the table of contents for clear layout on mobile and desktop

## Testing
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `GA_ID=TEST npm test` *(fails: analytics.spec.ts, navbar-visual.spec.ts, preloader-ripple.spec.ts, scroll.spec.ts; 1 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a020181c70832cb2ffb7d08ef3738f