### PR TITLE
Add SEO meta tags to policy pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -14,6 +14,11 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
+  <meta name="description" content="Find answers to common questions about orders, shipping, returns, and policies at HecCollects.">
+  <link rel="canonical" href="https://heccollects.github.io/faq.html">
+  <meta property="og:title" content="FAQ - HecCollects">
+  <meta property="og:description" content="Find answers to common questions about orders, shipping, returns, and policies at HecCollects.">
+  <meta property="og:url" content="https://heccollects.github.io/faq.html">
 </head>
 <body class="faq-page">
   <header class="navbar">

--- a/privacy.html
+++ b/privacy.html
@@ -14,6 +14,11 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
+  <meta name="description" content="Read how HecCollects collects, uses, and protects your information and how you can manage your data.">
+  <link rel="canonical" href="https://heccollects.github.io/privacy.html">
+  <meta property="og:title" content="Privacy Policy - HecCollects">
+  <meta property="og:description" content="Read how HecCollects collects, uses, and protects your information and how you can manage your data.">
+  <meta property="og:url" content="https://heccollects.github.io/privacy.html">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/returns.html
+++ b/returns.html
@@ -14,6 +14,11 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="HecCollects">
+  <meta name="description" content="Learn about HecCollects shipping policies, return instructions, refund timelines, and customer rights.">
+  <link rel="canonical" href="https://heccollects.github.io/returns.html">
+  <meta property="og:title" content="Shipping & Returns - HecCollects">
+  <meta property="og:description" content="Learn about HecCollects shipping policies, return instructions, refund timelines, and customer rights.">
+  <meta property="og:url" content="https://heccollects.github.io/returns.html">
 </head>
 <body class="returns-page">
   <header class="navbar">


### PR DESCRIPTION
## Summary
- add meta description, canonical link, and Open Graph tags to FAQ
- add meta description, canonical link, and Open Graph tags to Returns
- add meta description, canonical link, and Open Graph tags to Privacy Policy

## Testing
- `npm test` *(fails: 12 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a09272ae94832c8d0b3bef677d183f