### PR TITLE
Add canonical link to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <meta name="twitter:url" content="https://heccollects.github.io/">
   <meta name="twitter:image" content="logo.png">
   <meta name="theme-color" content="#1e3c72">
+  <link rel="canonical" href="https://heccollects.github.io/">
   <link rel="apple-touch-icon" href="logo-apple-touch.png">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">


### PR DESCRIPTION
## Summary
- add canonical URL link element in index.html head to reference production domain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a248ec74e8832c8f9830b8dd060c7f