### PR TITLE
Add noscript warning for JavaScript-disabled browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <meta name="apple-mobile-web-app-title" content="HecCollects">
   </head>
 <body>
+    <noscript><p>Please enable JavaScript to browse HecCollects.</p></noscript>
     <div id="preloader"><div class="dotted-loader"></div></div>
   <!-- Navbar -->
   <header class="navbar">

--- a/style.css
+++ b/style.css
@@ -35,6 +35,7 @@ section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z
 h1{font-size:2.4rem;text-shadow:0 3px 8px rgba(0,0,0,.4)}
 h2{font-size:1.9rem;color:var(--color-accent)}
 p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
+noscript p{margin:1rem;padding:1rem;text-align:center;background:var(--color-secondary);color:var(--white)}
 details{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.08)}
 summary{cursor:pointer;font-size:1.2rem;font-weight:600;color:var(--color-accent);list-style:none}
 summary::-webkit-details-marker{display:none}


### PR DESCRIPTION
## Summary
- Inform visitors without JavaScript to enable it via a `<noscript>` message
- Style the `<noscript>` notice for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26a2bbe54832cb7ce040c0d70793b