### PR TITLE
Add scheduled marketplace item fetcher

### DIFF
--- a/.github/workflows/update-items.yml
+++ b/.github/workflows/update-items.yml
@@ -1,0 +1,27 @@
+name: Update items
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Fetch latest items
+        env:
+          EBAY_APP_ID: ${{ secrets.EBAY_APP_ID }}
+        run: npm run fetch-items
+      - name: Commit and push if changed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: update items"
+            git push
+          fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "pretest": "node scripts/decode-font.js && node scripts/decode-logo.js && node scripts/decode-snapshots.js && playwright install --with-deps",
-    "test": "playwright test"
+    "test": "playwright test",
+    "fetch-items": "node scripts/fetch-items.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/fetch-items.js
+++ b/scripts/fetch-items.js
@@ -1,0 +1,66 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const OUTPUT = path.join(ROOT, 'items.json');
+
+const SEARCH_TERM = process.env.SEARCH_TERM || 'collectible';
+const LIMIT = parseInt(process.env.ITEM_LIMIT || '3', 10);
+
+async function fetchEbay() {
+  const appId = process.env.EBAY_APP_ID;
+  if (!appId) {
+    console.warn('EBAY_APP_ID not set; skipping eBay fetch');
+    return [];
+  }
+  const url = `https://svcs.ebay.com/services/search/FindingService/v1?OPERATION-NAME=findItemsByKeywords&SECURITY-APPNAME=${appId}&RESPONSE-DATA-FORMAT=JSON&keywords=${encodeURIComponent(SEARCH_TERM)}&paginationInput.entriesPerPage=${LIMIT}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    console.warn('eBay request failed', res.status);
+    return [];
+  }
+  const json = await res.json();
+  const items = json?.findItemsByKeywordsResponse?.[0]?.searchResult?.[0]?.item || [];
+  return items.slice(0, LIMIT).map(item => ({
+    image: item.galleryURL?.[0],
+    link: item.viewItemURL?.[0],
+    alt: item.title?.[0],
+    badge: item.condition?.[0]?.conditionDisplayName?.[0] || '',
+    stock: Number(item.sellingStatus?.[0]?.quantity || 1)
+  }));
+}
+
+async function fetchOfferUp() {
+  const url = `https://api.offerup.com/api/webapi/browse/search/?search=${encodeURIComponent(SEARCH_TERM)}&limit=${LIMIT}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn('OfferUp request failed', res.status);
+      return [];
+    }
+    const json = await res.json();
+    const items = json?.data?.items || json?.response?.sections?.[0]?.items || [];
+    return items.slice(0, LIMIT).map(it => ({
+      image: it?.images?.[0]?.images?.[0]?.url || it?.image?.url || it?.picture?.url,
+      link: it?.web_url || `https://offerup.com/item/detail/${it?.id}`,
+      alt: it?.title || '',
+      badge: it?.badges?.[0]?.name || '',
+      stock: 1
+    }));
+  } catch (err) {
+    console.warn('OfferUp fetch error', err);
+    return [];
+  }
+}
+
+async function main() {
+  const [ebay, offerup] = await Promise.all([fetchEbay(), fetchOfferUp()]);
+  const data = { ebay, offerup };
+  await fs.writeFile(OUTPUT, JSON.stringify(data, null, 2));
+  console.log(`Wrote ${OUTPUT}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to fetch latest eBay and OfferUp listings and write `items.json`
- expose `npm run fetch-items` for manual runs
- schedule GitHub Action to refresh items daily and commit updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a278be065c832c8bc892790debcd87