### PR TITLE
Rename privacy-content to policy-content

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -43,7 +43,7 @@
       <span class="line" aria-hidden="true"></span>
     </button>
   </header>
-  <main class="faq-content">
+  <main class="policy-content">
     <h1>Frequently Asked Questions</h1>
     <nav class="toc">
       <ol>

--- a/style.css
+++ b/style.css
@@ -100,7 +100,7 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 .checkbox-group label{display:flex;align-items:center;gap:.25rem}
 .privacy{font-size:.8rem}
 .privacy a{color:var(--color-accent)}
-.privacy-content{padding:2rem;max-width:800px;margin:auto;color:var(--white)}
+.policy-content{padding:calc(env(safe-area-inset-top)+5rem) 2rem 2rem;max-width:800px;margin:auto;color:var(--white)}
 /* Ripple */
 .ripple{position:absolute;border-radius:50%;transform:scale(0);background:rgba(255,255,255,.35);animation:ripple .6s linear}
 @keyframes ripple{to{transform:scale(4);opacity:0}}


### PR DESCRIPTION
## Summary
- unify policy page styling with new `.policy-content` class
- pad policy content to clear fixed navbar
- use shared policy content class on FAQ page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ae6bc184832cbea9056e8c4aa9f8