### PR TITLE
Add scroll-margin offsets for anchor targets

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@
 --color-primary:#1e3c72;
 --color-secondary:#2a5298;
 --color-accent:#f28c2f;
+--navbar-height:calc(env(safe-area-inset-top)+5rem);
 }
 /* ---------- Reset & Base ---------- */
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -27,9 +28,10 @@ section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z
 .logo{width:100px;height:100px;border-radius:50%;object-fit:cover;box-shadow:0 6px 14px rgba(0,0,0,.5)}
 h1{font-size:2.4rem;text-shadow:0 3px 8px rgba(0,0,0,.4)}
 h2{font-size:1.9rem;color:var(--color-accent)}
+h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]{scroll-margin-top:var(--navbar-height)}
 p{font-size:1.05rem;max-width:680px;margin-bottom:.2rem}
 noscript p{margin:1rem;padding:1rem;text-align:center;background:var(--color-secondary);color:var(--white)}
-details{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.08)}
+details{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.08);scroll-margin-top:var(--navbar-height)}
 summary{cursor:pointer;font-size:1.2rem;font-weight:600;color:var(--color-accent);list-style:none}
 summary::-webkit-details-marker{display:none}
 summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}


### PR DESCRIPTION
## Summary
- add `--navbar-height` custom property to define scroll offset
- apply `scroll-margin-top` to headings and details so anchors aren't hidden behind the navbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2b4bfe114832c953591a42b59a1fa