### PR TITLE
feat: improve mobile featured item layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -130,6 +130,9 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 h1{font-size:1.9rem}
 h2{font-size:1.65rem}
 .btn{font-size:.95rem;padding:.8rem 1rem}
+.featured-items{gap:.8rem}
+.featured-items a{flex:0 0 45%}
+.featured-items img{margin-bottom:.3rem}
 }
 @media(hover:hover) and (pointer:fine){
 section{background-attachment:fixed}


### PR DESCRIPTION
## Summary
- widen featured item cards on small screens
- tweak item spacing for mobile consistency

## Testing
- `npm test` *(fails: navbar layout should match snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b9828b60832c919ffcd35027622a