### PR TITLE
Adjust details spacing and toc styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,7 +36,7 @@ summary{cursor:pointer;font-size:1.2rem;font-weight:600;color:var(--color-accent
 summary::-webkit-details-marker{display:none}
 summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 /* ---------- Table of Contents ---------- */
-.toc{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.08);text-align:left}
+.toc{margin:1rem 0;padding:1rem;border:2px solid rgba(255,255,255,.18);border-radius:1rem;background:rgba(255,255,255,.05);text-align:left;font-size:.95rem}
 .toc>ol{list-style:none;padding-left:0;display:flex;flex-direction:column;gap:.5rem}
 .toc ol ol{padding-left:1rem}
 .toc a{text-decoration:none;color:var(--color-accent);font-weight:600}
@@ -133,6 +133,7 @@ h2{font-size:1.65rem}
 .featured-items{gap:.8rem}
 .featured-items a{flex:0 0 45%}
 .featured-items img{margin-bottom:.3rem}
+details{margin:.6rem 0;padding:.6rem}
 }
 @media(hover:hover) and (pointer:fine){
 section{background-attachment:fixed}


### PR DESCRIPTION
## Summary
- Tighten `details` padding and margin on small screens
- Give `.toc` lighter background and smaller text to distinguish from collapsible sections

## Testing
- `npm test` *(fails: snapshot mismatch for navbar layout)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bca95dc0832c9323f560bc0492b6