### PR TITLE
Tighten featured-item badge display

### DIFF
--- a/items.json
+++ b/items.json
@@ -4,22 +4,19 @@
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://www.ebay.com/itm/376470178564",
       "alt": "Featured eBay collectible",
-      "badge": "Only 1 left",
-      "stock": 1
+      "badge": "Only 1 left"
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://ebay.us/m/vs5p1e",
       "alt": "Featured eBay collectible 2",
-      "badge": "Only 1 left",
       "stock": 1
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
       "link": "https://ebay.us/m/VTMaDx",
       "alt": "Featured eBay collectible 3",
-      "badge": "Only 1 left",
-      "stock": 1
+      "badge": "Only 1 left"
     }
   ],
   "offerup": [
@@ -27,21 +24,18 @@
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://offerup.co/44T5cRnMIVb",
       "alt": "Featured OfferUp item",
-      "badge": "Only 1 left",
       "stock": 1
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://offerup.co/UR4k8b1RIVb",
       "alt": "Featured OfferUp item 2",
-      "badge": "Only 1 left",
-      "stock": 1
+      "badge": "Only 1 left"
     },
     {
       "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
       "link": "https://offerup.co/iAT3Vh4RIVb",
       "alt": "Featured OfferUp item 3",
-      "badge": "Only 1 left",
       "stock": 1
     }
   ]

--- a/main.js
+++ b/main.js
@@ -354,10 +354,7 @@
             if (item.badge || item.stock) {
               const meta = document.createElement('span');
               meta.className = 'item-meta';
-              const parts = [];
-              if (item.badge) parts.push(item.badge);
-              if (item.stock) parts.push(`Only ${item.stock} left`);
-              meta.textContent = parts.join(' – ');
+              meta.textContent = item.badge ? item.badge : `Only ${item.stock} left`;
               link.appendChild(meta);
             }
             container.appendChild(link);

--- a/style.css
+++ b/style.css
@@ -60,7 +60,7 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 .featured-items::-webkit-scrollbar{display:none}
 .featured-items a{display:flex;flex-direction:column;align-items:center;text-decoration:none;color:var(--white);flex:0 0 18%;scroll-snap-align:center;overflow:hidden;border-radius:.6rem;position:relative}
 .featured-items img{width:100%;aspect-ratio:16/9;height:auto;object-fit:contain;border-radius:.6rem;margin-bottom:.25rem;transition:transform .3s,box-shadow .3s}
-.item-meta{position:absolute;top:.4rem;left:.4rem;background:var(--color-accent);color:var(--black);padding:.2rem .4rem;border-radius:.4rem;font-size:.7rem;font-weight:600}
+.item-meta{position:absolute;top:.4rem;left:.4rem;background:var(--color-accent);color:var(--black);padding:.1rem .3rem;border-radius:.3rem;font-size:.6rem;font-weight:600;max-width:calc(100% - .8rem);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .featured-items a:hover img{transform:scale(1.08);box-shadow:0 8px 16px rgba(0,0,0,.4)}
 .promo{margin-top:.8rem;font-size:.9rem;color:var(--color-accent)}
 /* Feature marquee */


### PR DESCRIPTION
## Summary
- ensure featured items use either a badge or stock count, not both
- favor badges over stock counts when building featured-item meta text
- clamp and shrink featured-item badges so text stays within thumbnail bounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33a51fdb0832c920a3651514530b2