### PR TITLE
Ensure policy headings clear navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
 --color-primary:#1e3c72;
 --color-secondary:#2a5298;
 --color-accent:#f28c2f;
---navbar-height:calc(env(safe-area-inset-top)+5rem);
+--navbar-height:calc(env(safe-area-inset-top) + 5rem);
 }
 /* ---------- Reset & Base ---------- */
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -102,7 +102,7 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 .checkbox-group label{display:flex;align-items:center;gap:.25rem}
 .privacy{font-size:.8rem}
 .privacy a{color:var(--color-accent)}
-.policy-content{padding:calc(env(safe-area-inset-top)+5rem) 2rem 2rem;max-width:800px;margin:auto;color:var(--white)}
+.policy-content{padding:0 2rem 2rem;padding-top:var(--navbar-height);max-width:800px;margin:auto;color:var(--white)}
 /* Ripple */
 .ripple{position:absolute;border-radius:50%;transform:scale(0);background:rgba(255,255,255,.35);animation:ripple .6s linear}
 @keyframes ripple{to{transform:scale(4);opacity:0}}

--- a/tests/policy-h1.spec.ts
+++ b/tests/policy-h1.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+const pages = ['faq.html', 'returns.html', 'privacy.html'];
+
+for (const name of pages) {
+  test(`${name} h1 is below navbar`, async ({ page }) => {
+    const filePath = path.resolve(__dirname, `../${name}`);
+    await page.goto('file://' + filePath);
+    await page.evaluate(() => (document as any).fonts.ready);
+
+    const navBox = await page.locator('.navbar').boundingBox();
+    const h1Box = await page.locator('h1').boundingBox();
+    if (!navBox || !h1Box) throw new Error('Elements not found');
+    expect(h1Box.y).toBeGreaterThanOrEqual(navBox.height);
+  });
+}


### PR DESCRIPTION
## Summary
- use `--navbar-height` variable for policy page top padding
- add Playwright test to verify policy headings appear below navbar on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c1b1db4c832c855f219dafe036dd