### PR TITLE
Adjust thumbnail height to maintain 16:9 ratio

### DIFF
--- a/main.js
+++ b/main.js
@@ -346,7 +346,7 @@
                 const small = new URL(item.image);
                 small.searchParams.set('width', String(half));
                 img.width = width;
-                img.height = width;
+                img.height = Math.round(width * 9 / 16);
                 img.srcset = `${small.toString()} ${half}w, ${item.image} ${width}w`;
               }
             } catch {}


### PR DESCRIPTION
## Summary
- compute thumbnail height from width to preserve 16:9 aspect ratio

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cdd08490832cb0e4798f645fc260