### PR TITLE
Remove redundant tabindex attributes from navigation links

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -22,19 +22,19 @@
 </head>
 <body class="faq-page">
   <header class="navbar">
-    <a href="index.html#home" class="brand" tabindex="0">
+    <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
     </a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-      <a href="index.html#ebay" tabindex="0">eBay</a>
-      <a href="index.html#offerup" tabindex="0">OfferUp</a>
-      <a href="index.html#about" tabindex="0">About Me</a>
-      <a href="index.html#testimonials" tabindex="0">Testimonials</a>
-      <a href="index.html#subscribe" tabindex="0">Subscribe</a>
-      <a href="index.html#contact" tabindex="0">Business Inquiries</a>
-      <a href="faq.html" tabindex="0" aria-current="page">FAQ</a>
-      <a href="returns.html" tabindex="0">Returns</a>
-      <a href="privacy.html" tabindex="0">Privacy Policy</a>
+      <a href="index.html#ebay">eBay</a>
+      <a href="index.html#offerup">OfferUp</a>
+      <a href="index.html#about">About Me</a>
+      <a href="index.html#testimonials">Testimonials</a>
+      <a href="index.html#subscribe">Subscribe</a>
+      <a href="index.html#contact">Business Inquiries</a>
+      <a href="faq.html" aria-current="page">FAQ</a>
+      <a href="returns.html">Returns</a>
+      <a href="privacy.html">Privacy Policy</a>
     </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line" aria-hidden="true"></span>

--- a/index.html
+++ b/index.html
@@ -152,19 +152,19 @@
     <div id="preloader"><div class="dotted-loader"></div></div>
   <!-- Navbar -->
   <header class="navbar">
-    <a href="#home" class="brand" tabindex="0">
+    <a href="#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
     </a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-      <a href="#ebay" tabindex="0">eBay</a>
-      <a href="#offerup" tabindex="0">OfferUp</a>
-      <a href="#about" tabindex="0">About Me</a>
-      <a href="#testimonials" tabindex="0">Testimonials</a>
-      <a href="#subscribe" tabindex="0">Subscribe</a>
-      <a href="#contact" tabindex="0">Business Inquiries</a>
-      <a href="faq.html" tabindex="0">FAQ</a>
-      <a href="returns.html" tabindex="0">Returns</a>
-      <a href="privacy.html" tabindex="0">Privacy Policy</a>
+      <a href="#ebay">eBay</a>
+      <a href="#offerup">OfferUp</a>
+      <a href="#about">About Me</a>
+      <a href="#testimonials">Testimonials</a>
+      <a href="#subscribe">Subscribe</a>
+      <a href="#contact">Business Inquiries</a>
+      <a href="faq.html">FAQ</a>
+      <a href="returns.html">Returns</a>
+      <a href="privacy.html">Privacy Policy</a>
     </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line" aria-hidden="true"></span>

--- a/privacy.html
+++ b/privacy.html
@@ -62,19 +62,19 @@
 </head>
 <body class="privacy-page">
   <header class="navbar">
-    <a href="index.html#home" class="brand" tabindex="0">
+    <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
     </a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-      <a href="index.html#ebay" tabindex="0">eBay</a>
-      <a href="index.html#offerup" tabindex="0">OfferUp</a>
-      <a href="index.html#about" tabindex="0">About Me</a>
-      <a href="index.html#testimonials" tabindex="0">Testimonials</a>
-      <a href="index.html#subscribe" tabindex="0">Subscribe</a>
-      <a href="index.html#contact" tabindex="0">Business Inquiries</a>
-      <a href="faq.html" tabindex="0">FAQ</a>
-      <a href="returns.html" tabindex="0">Returns</a>
-      <a href="privacy.html" tabindex="0" aria-current="page">Privacy Policy</a>
+      <a href="index.html#ebay">eBay</a>
+      <a href="index.html#offerup">OfferUp</a>
+      <a href="index.html#about">About Me</a>
+      <a href="index.html#testimonials">Testimonials</a>
+      <a href="index.html#subscribe">Subscribe</a>
+      <a href="index.html#contact">Business Inquiries</a>
+      <a href="faq.html">FAQ</a>
+      <a href="returns.html">Returns</a>
+      <a href="privacy.html" aria-current="page">Privacy Policy</a>
     </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line" aria-hidden="true"></span>

--- a/returns.html
+++ b/returns.html
@@ -22,19 +22,19 @@
 </head>
 <body class="returns-page">
   <header class="navbar">
-    <a href="index.html#home" class="brand" tabindex="0">
+    <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
     </a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-      <a href="index.html#ebay" tabindex="0">eBay</a>
-      <a href="index.html#offerup" tabindex="0">OfferUp</a>
-      <a href="index.html#about" tabindex="0">About Me</a>
-      <a href="index.html#testimonials" tabindex="0">Testimonials</a>
-      <a href="index.html#subscribe" tabindex="0">Subscribe</a>
-      <a href="index.html#contact" tabindex="0">Business Inquiries</a>
-      <a href="faq.html" tabindex="0">FAQ</a>
-      <a href="returns.html" tabindex="0" aria-current="page">Returns</a>
-      <a href="privacy.html" tabindex="0">Privacy Policy</a>
+      <a href="index.html#ebay">eBay</a>
+      <a href="index.html#offerup">OfferUp</a>
+      <a href="index.html#about">About Me</a>
+      <a href="index.html#testimonials">Testimonials</a>
+      <a href="index.html#subscribe">Subscribe</a>
+      <a href="index.html#contact">Business Inquiries</a>
+      <a href="faq.html">FAQ</a>
+      <a href="returns.html" aria-current="page">Returns</a>
+      <a href="privacy.html">Privacy Policy</a>
     </nav>
     <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
       <span class="line" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- Remove unnecessary `tabindex="0"` from navigation anchors in index, FAQ, returns, and privacy pages so anchors rely on default focus behavior

## Testing
- `npx playwright test tests/menu.spec.ts --project=desktop-chromium`


------
https://chatgpt.com/codex/tasks/task_e_68a3d964be84832cb77c2b937a3acf8a