### PR TITLE
Add market history chart using Chart.js

### DIFF
--- a/sold.html
+++ b/sold.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <link rel="apple-touch-icon" href="logo-apple-touch.png">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="icon" type="image/png" href="logo.png">
+  <title>Market History - HecCollects</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="theme.css">
+  <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
+  <script src="analytics.js" defer></script>
+</head>
+<body>
+  <header class="navbar">
+    <a href="index.html#home" class="brand">
+      <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
+    </a>
+    <nav id="nav-menu" class="nav-menu" aria-hidden="true">
+      <a href="index.html#ebay">eBay</a>
+      <a href="index.html#offerup">OfferUp</a>
+      <a href="index.html#about">About Me</a>
+      <a href="index.html#testimonials">Testimonials</a>
+      <a href="index.html#subscribe">Subscribe</a>
+      <a href="index.html#contact">Business Inquiries</a>
+      <a href="faq.html">FAQ</a>
+      <a href="returns.html">Returns</a>
+      <a href="privacy.html">Privacy Policy</a>
+    </nav>
+    <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
+      <span class="line" aria-hidden="true"></span>
+      <span class="line" aria-hidden="true"></span>
+      <span class="line" aria-hidden="true"></span>
+    </button>
+  </header>
+  <main class="policy-content">
+    <h1>Market History</h1>
+    <canvas id="price-chart" aria-label="Price history chart"></canvas>
+  </main>
+  <footer class="site-footer">
+    <a href="index.html">Home</a>
+    <a href="faq.html">FAQ</a>
+    <a href="returns.html">Returns</a>
+    <a href="privacy.html">Privacy Policy</a>
+  </footer>
+  <script src="main.js" defer></script>
+  <script src="page-transitions.js" defer></script>
+  <script type="module" src="sold.js"></script>
+</body>
+</html>

--- a/sold.js
+++ b/sold.js
@@ -1,0 +1,48 @@
+import Chart from 'https://cdn.jsdelivr.net/npm/chart.js/auto';
+
+const soldHistory = [
+  { date: '2024-01', price: 110 },
+  { date: '2024-02', price: 115 },
+  { date: '2024-03', price: 107 },
+  { date: '2024-04', price: 120 },
+  { date: '2024-05', price: 125 },
+  { date: '2024-06', price: 119 }
+];
+
+const ctx = document.getElementById('price-chart');
+
+new Chart(ctx, {
+  type: 'line',
+  data: {
+    labels: soldHistory.map(p => p.date),
+    datasets: [{
+      label: 'Sold Price',
+      data: soldHistory.map(p => p.price),
+      borderColor: '#f28c2f',
+      backgroundColor: 'rgba(242, 140, 47, 0.2)',
+      borderWidth: 2,
+      fill: true,
+      tension: 0.3,
+      pointRadius: 0
+    }]
+  },
+  options: {
+    interaction: {
+      mode: 'index',
+      intersect: false
+    },
+    plugins: {
+      legend: { display: false }
+    },
+    scales: {
+      x: {
+        grid: { color: 'rgba(255,255,255,0.1)' },
+        ticks: { color: '#fff' }
+      },
+      y: {
+        grid: { color: 'rgba(255,255,255,0.1)' },
+        ticks: { color: '#fff' }
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add new `sold.html` with canvas for displaying a price history chart
- use `sold.js` to import Chart.js and render a styled line chart with hover tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ec0d8a00832cb531bcc5242271b2