### PR TITLE
Improve accessibility and responsiveness of sold listings

### DIFF
--- a/sold.html
+++ b/sold.html
@@ -52,18 +52,21 @@
       <p id="avg-price"></p>
       <ul id="monthly-sales"></ul>
     </div>
-    <canvas id="sales-chart" aria-label="Sales chart"></canvas>
-    <table id="sold-table" aria-label="Sold items">
-      <thead>
-        <tr>
-          <th scope="col">Item</th>
-          <th scope="col">Price</th>
-          <th scope="col">Date</th>
-          <th scope="col">Location</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <canvas id="sales-chart" aria-label="Sales chart" role="img"></canvas>
+    <div class="table-container">
+      <table id="sold-table" aria-labelledby="sold-table-caption">
+        <caption id="sold-table-caption">Sold items with prices, dates, and locations</caption>
+        <thead>
+          <tr>
+            <th scope="col">Item</th>
+            <th scope="col">Price</th>
+            <th scope="col">Date</th>
+            <th scope="col">Location</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </main>
   <footer class="site-footer">
     <a href="index.html">Home</a>

--- a/style.css
+++ b/style.css
@@ -232,3 +232,29 @@ select:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
+
+/* Sold listings table and chart */
+.table-container{
+  overflow-x:auto;
+}
+#sold-table{
+  width:100%;
+  border-collapse:collapse;
+  margin-top:1rem;
+}
+#sold-table th,#sold-table td{
+  padding:.5rem;
+  text-align:left;
+  border-bottom:1px solid rgba(255,255,255,.2);
+}
+#sales-chart{
+  max-width:100%;
+  height:auto;
+  margin-top:1rem;
+}
+@media(max-width:640px){
+  #sold-table th,#sold-table td{
+    font-size:.9rem;
+    white-space:nowrap;
+  }
+}


### PR DESCRIPTION
## Summary
- add caption and ARIA labelling to the sold listings table
- make the sales chart and table responsive on small screens

## Testing
- `npm test`
- `npx pa11y --standard WCAG2AA file://$(pwd)/sold.html` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a51bdd04f4832cae67548c009f7ff5