### PR TITLE
feat: show sales platforms on sold list

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -12,6 +12,17 @@ function parsePrice(priceStr) {
   return Number(priceStr?.replace(/[^0-9.-]+/g, ''));
 }
 
+function formatPlatform(platform) {
+  switch ((platform || '').toLowerCase()) {
+    case 'ebay':
+      return 'eBay';
+    case 'tcgplayer':
+      return 'TCGplayer';
+    default:
+      return platform || '';
+  }
+}
+
 function filterItems(items) {
   const value = dateFilterEl.value;
   if (value === 'all') return items;
@@ -54,10 +65,13 @@ function renderTable(items) {
     const date = item.date ? new Date(item.date) : null;
     dateTd.textContent = date && !isNaN(date) ? date.toLocaleDateString() : '';
 
+    const platformTd = document.createElement('td');
+    platformTd.textContent = formatPlatform(item.platform);
+
     const locationTd = document.createElement('td');
     locationTd.textContent = item.location || '';
 
-    tr.append(itemTd, priceTd, dateTd, locationTd);
+    tr.append(itemTd, priceTd, dateTd, platformTd, locationTd);
     return tr;
   });
 
@@ -147,7 +161,18 @@ async function loadSoldItems() {
       return;
     }
 
-    allItems = items;
+    allItems = items.map(item => ({
+      title: item.title || '',
+      image: item.image || '',
+      link: item.link || item.url || '',
+      price:
+        item.price && typeof item.price === 'object'
+          ? `${item.price.currency || ''} ${item.price.value}`.trim()
+          : item.price || '',
+      date: item.date || '',
+      location: item.location || '',
+      platform: item.platform || ''
+    }));
     statusEl.textContent = '';
     render();
   } catch (err) {
@@ -157,6 +182,7 @@ async function loadSoldItems() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  dateFilterEl.value = '90';
   loadSoldItems();
   dateFilterEl.addEventListener('change', render);
 });

--- a/sold.html
+++ b/sold.html
@@ -42,9 +42,8 @@
     <div class="controls">
       <label for="date-filter">Date Range:</label>
       <select id="date-filter">
-        <option value="all">All Time</option>
         <option value="30">Last 30 Days</option>
-        <option value="90">Last 90 Days</option>
+        <option value="90" selected>Last 90 Days</option>
         <option value="365">Last Year</option>
       </select>
     </div>
@@ -55,12 +54,13 @@
     <canvas id="sales-chart" aria-label="Sales chart" role="img"></canvas>
     <div class="table-container">
       <table id="sold-table" aria-labelledby="sold-table-caption">
-        <caption id="sold-table-caption">Sold items with prices, dates, and locations</caption>
+        <caption id="sold-table-caption">Sold items with prices, dates, platforms, and locations</caption>
         <thead>
           <tr>
             <th scope="col">Item</th>
             <th scope="col">Price</th>
             <th scope="col">Date</th>
+            <th scope="col">Platform</th>
             <th scope="col">Location</th>
           </tr>
         </thead>

--- a/tests/sold.spec.ts
+++ b/tests/sold.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../sold.html');
+
+test('sold page defaults to last 90 days and shows platform column', async ({ page }) => {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch;
+    window.fetch = (url, options) => {
+      if (typeof url === 'string' && url.endsWith('sold-items.json')) {
+        return Promise.resolve(
+          new Response('[]', {
+            headers: { 'Content-Type': 'application/json' }
+          })
+        );
+      }
+      return originalFetch(url, options);
+    };
+    window.Chart = function () {
+      return {
+        data: { labels: [], datasets: [{ data: [] }] },
+        update() {},
+        destroy() {}
+      };
+    };
+  });
+
+  await page.goto('file://' + filePath);
+  await page.evaluate(() => (document as any).fonts.ready);
+
+  await expect(page.locator('#date-filter')).toHaveValue('90');
+  await expect(page.locator('#sold-table thead th').nth(3)).toHaveText('Platform');
+});


### PR DESCRIPTION
## Summary
- default sold page to last 90 days and show platform column
- parse platform field from sold-items data
- add tests for platform column

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52f32e538832c8c955e758e65e566