### PR TITLE
Constrain sold listings chart height

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -3,7 +3,9 @@ const tableBody = document.querySelector('#sold-table tbody');
 const avgPriceEl = document.getElementById('avg-price');
 const monthlySalesEl = document.getElementById('monthly-sales');
 const dateFilterEl = document.getElementById('date-filter');
-const chartCtx = document.getElementById('sales-chart').getContext('2d');
+const chartCanvas = document.getElementById('sales-chart');
+chartCanvas.height = 300;
+const chartCtx = chartCanvas.getContext('2d');
 
 let allItems = [];
 let chart;
@@ -137,7 +139,8 @@ function updateChart(items) {
             beginAtZero: false
           }
         }
-      }
+      },
+      height: 300
     });
   }
 }

--- a/sold.html
+++ b/sold.html
@@ -13,7 +13,7 @@
   <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
   <script src="analytics.js" defer></script>
 </head>
-<body>
+<body class="sold-page">
   <header class="navbar">
     <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">

--- a/style.css
+++ b/style.css
@@ -234,8 +234,16 @@ select:focus-visible {
 }
 
 /* Sold listings table and chart */
-.table-container{
+.sold-page .policy-content{
+  display:flex;
+  flex-direction:column;
+  max-height:calc(100vh - var(--navbar-height));
+  overflow:hidden;
+}
+.sold-page .table-container{
   overflow-x:auto;
+  overflow-y:auto;
+  flex:1;
 }
 #sold-table{
   width:100%;
@@ -247,10 +255,11 @@ select:focus-visible {
   text-align:left;
   border-bottom:1px solid rgba(255,255,255,.2);
 }
-#sales-chart{
+.sold-page #sales-chart{
   max-width:100%;
-  height:auto;
+  height:300px;
   margin-top:1rem;
+  flex:0 0 auto;
 }
 @media(max-width:640px){
   #sold-table th,#sold-table td{


### PR DESCRIPTION
## Summary
- Fix sold listings chart height at 300px and limit main content to viewport.
- Pass explicit height to Chart.js configuration and canvas.
- Scope sold page styles with `sold-page` body class.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5368a5bfc832c9c3341c4500c51a9