### PR TITLE
Adjust section content padding for safe areas

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ body{font-family:'Poppins',sans-serif;background:linear-gradient(135deg,var(--bl
 /* ---------- Sections ---------- */
 section{position:relative;height:100dvh;min-height:100dvh;scroll-snap-align:start;display:flex;align-items:center;justify-content:center;text-align:center;background-position:center 20%;background-size:cover;background-repeat:no-repeat;background-attachment:scroll}
 section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z-index:0}
-.section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem}
+.section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2.5rem calc(env(safe-area-inset-right) + 2.5rem) 2.5rem calc(env(safe-area-inset-left) + 2.5rem)}
 /* ---------- Card ---------- */
 .card{background:rgba(255,255,255,.08);backdrop-filter:blur(8px);border:2px solid rgba(255,255,255,.18);border-radius:1.6rem;padding:2rem 1.4rem;width:100%;max-width:460px;box-shadow:0 25px 50px rgba(0,0,0,.35);transition:transform .45s cubic-bezier(.34,1.56,.64,1);display:flex;flex-direction:column;align-items:center;gap:1.4rem}
 .card:hover{transform:translateY(-10px) rotateX(5deg) rotateY(-5deg)}


### PR DESCRIPTION
## Summary
- include safe-area insets in `.section-content` padding to preserve spacing on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fff4c730832c97923d42400572a4