### PR TITLE
Ensure policy pages have comfortable margins

### DIFF
--- a/style.css
+++ b/style.css
@@ -109,7 +109,12 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 .checkbox-group label{display:flex;align-items:center;gap:.25rem}
 .privacy{font-size:.8rem}
 .privacy a{color:var(--color-accent)}
-.policy-content{padding:0 2rem 2rem;padding-top:var(--navbar-height);max-width:800px;margin:auto;color:var(--white)}
+.policy-content{padding:
+    var(--navbar-height)
+    calc(env(safe-area-inset-right) + 2rem)
+    2rem
+    calc(env(safe-area-inset-left) + 2rem);
+    max-width:800px;margin:auto;color:var(--white)}
 /* Ripple */
 .ripple{position:absolute;border-radius:50%;transform:scale(0);background:rgba(255,255,255,.35);animation:ripple .6s linear}
 @keyframes ripple{to{transform:scale(4);opacity:0}}


### PR DESCRIPTION
## Summary
- adjust `.policy-content` padding to respect safe areas and navbar height

## Testing
- `npm test`
- Verified rendered padding on `faq.html`, `returns.html`, `privacy.html`, and `sold.html` with Playwright

------
https://chatgpt.com/codex/tasks/task_e_68a604dc629c832cacb313be9b871af9