### PR TITLE
feat: adjust cookie banner padding for safe areas

### DIFF
--- a/style.css
+++ b/style.css
@@ -185,7 +185,7 @@ section{background-attachment:fixed}
 75%{box-shadow:0 -2.6em 0 0 rgba(242,140,47,.2),1.8em -1.8em 0 0 rgba(242,140,47,.2),2.5em 0 0 0 rgba(242,140,47,.2),1.75em 1.75em 0 0 rgba(242,140,47,.2),0 2.5em 0 0 rgba(242,140,47,.5),-1.8em 1.8em 0 0 rgba(242,140,47,.7),-2.6em 0 0 0 var(--color-accent),-1.8em -1.8em 0 0 rgba(242,140,47,.2);}
 87.5%{box-shadow:0 -2.6em 0 0 rgba(242,140,47,.2),1.8em -1.8em 0 0 rgba(242,140,47,.2),2.5em 0 0 0 rgba(242,140,47,.2),1.75em 1.75em 0 0 rgba(242,140,47,.2),0 2.5em 0 0 rgba(242,140,47,.2),-1.8em 1.8em 0 0 rgba(242,140,47,.5),-2.6em 0 0 0 rgba(242,140,47,.7),-1.8em -1.8em 0 0 var(--color-accent);}
 }
-.cookie-banner{position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,.85);color:var(--white);padding:.6rem 1rem calc(env(safe-area-inset-bottom)+.6rem);font-size:.85rem;display:flex;justify-content:space-between;align-items:center;z-index:100000}
+.cookie-banner{position:fixed;bottom:0;left:0;right:0;background:rgba(0,0,0,.85);color:var(--white);padding:.6rem calc(env(safe-area-inset-right) + 1rem) calc(env(safe-area-inset-bottom) + .6rem) calc(env(safe-area-inset-left) + 1rem);font-size:.85rem;display:flex;justify-content:space-between;align-items:center;z-index:100000}
 #cookie-btn{background:var(--color-accent);color:var(--white);border:none;border-radius:.3rem;padding:.3rem .7rem;cursor:pointer}
 @media (prefers-reduced-motion: reduce){
 *{


### PR DESCRIPTION
## Summary
- ensure cookie banner padding respects device safe areas

## Testing
- `npm test` *(fails: 2 interrupted, 78 did not run, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a60e15dd74832cb2af4261c6ab786b