### PR TITLE
feat: track item condition and quantity sold

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Playwright Test will execute the browser-based tests.
 `scripts/update-sold.js` pulls recent sales data from eBay and TCGplayer and
 writes `sold-items.json`.
 
+Each entry in `sold-items.json` contains:
+
+- `title` – item title.
+- `image` – thumbnail image URL.
+- `url` – link to the listing.
+- `price` – object with `value` and `currency`.
+- `date` – sale completion date.
+- `location` – item location.
+- `platform` – source marketplace (`ebay` or `tcgplayer`).
+- `condition` – item condition when available.
+- `quantitySold` – number of units sold when available.
+- `sellerCount` – number of sellers offering the item if provided by the API, otherwise `null`.
+
 Set the following environment variables before running the script:
 
 - `EBAY_APP_ID` – eBay developer application ID.

--- a/scripts/update-sold.js
+++ b/scripts/update-sold.js
@@ -53,7 +53,13 @@ async function fetchEbaySold() {
       location: item.location?.[0] || '',
       url: item.viewItemURL?.[0] || '',
       image: item.galleryURL?.[0] || '',
-      platform: 'ebay'
+      platform: 'ebay',
+      condition:
+        item.condition?.[0]?.conditionDisplayName?.[0] ||
+        item.conditionId?.[0] ||
+        '',
+      quantitySold: Number(item.sellingStatus?.[0]?.quantitySold?.[0] || 0),
+      sellerCount: item.sellerInfo?.[0]?.sellerUserName ? 1 : null
     }));
   } catch (err) {
     console.warn('eBay sold fetch error', err);
@@ -116,7 +122,19 @@ async function fetchTcgPlayerSold() {
       location: order.address?.region || '',
       url: '',
       image: '',
-      platform: 'tcgplayer'
+      platform: 'tcgplayer',
+      condition:
+        order.condition ||
+        order.product?.conditionName ||
+        order.productConditionId ||
+        '',
+      quantitySold: Number(
+        order.quantity ||
+        order.quantitySold ||
+        order.orderItems?.[0]?.quantity ||
+        0
+      ),
+      sellerCount: Number(order.sellerCount || (order.storeSellerId ? 1 : 0))
     }));
   } catch (err) {
     console.warn('TCGplayer sold fetch error', err);

--- a/sold-items.json
+++ b/sold-items.json
@@ -2,25 +2,31 @@
   {
     "title": "Vintage Camera",
     "image": "https://example.com/images/camera.jpg",
-    "link": "https://example.com/vintage-camera",
+    "url": "https://example.com/vintage-camera",
     "price": {
       "value": 150,
       "currency": "USD"
     },
     "date": "2024-03-01",
     "location": "New York, NY",
-    "platform": "ebay"
+    "platform": "ebay",
+    "condition": "Used",
+    "quantitySold": 1,
+    "sellerCount": 1
   },
   {
     "title": "Retro Game Console",
     "image": "https://example.com/images/console.jpg",
-    "link": "https://example.com/retro-console",
+    "url": "https://example.com/retro-console",
     "price": {
       "value": 80,
       "currency": "USD"
     },
     "date": "2024-02-15",
     "location": "Los Angeles, CA",
-    "platform": "tcgplayer"
+    "platform": "tcgplayer",
+    "condition": "Near Mint",
+    "quantitySold": 2,
+    "sellerCount": null
   }
 ]


### PR DESCRIPTION
## Summary
- capture condition, quantity sold, and seller count from eBay and TCGplayer APIs
- record new fields in sold-items.json and document schema
- clarify seller count handling when data is unavailable

## Testing
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68a6209ed554832c99eaa840bf586e7a