### PR TITLE
Add chart range filters to sold listings page

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -6,6 +6,14 @@ const dateFilterEl = document.getElementById('date-filter');
 const chartCanvas = document.getElementById('sales-chart');
 chartCanvas.height = 300;
 const chartCtx = chartCanvas.getContext('2d');
+let rangeButtons;
+rangeButtons = document.querySelectorAll('.range-buttons button');
+rangeButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const range = btn.id.replace('range-', '');
+    filterByRange(range);
+  });
+});
 
 let allItems = [];
 let chart;
@@ -35,6 +43,23 @@ function filterItems(items) {
     const date = item.date ? new Date(item.date) : null;
     return date && !isNaN(date) && date >= cutoff;
   });
+}
+
+function filterByRange(range) {
+  const daysMap = { '1m': 30, '3m': 90, '6m': 180, '1y': 365 };
+  const days = daysMap[range] || 90;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const filtered = allItems.filter(item => {
+    const date = item.date ? new Date(item.date) : null;
+    return date && !isNaN(date) && date >= cutoff;
+  });
+  if (rangeButtons) {
+    rangeButtons.forEach(btn => {
+      btn.classList.toggle('active', btn.id === `range-${range}`);
+    });
+  }
+  updateChart(filtered);
 }
 
 function renderTable(items) {
@@ -178,6 +203,7 @@ async function loadSoldItems() {
     }));
     statusEl.textContent = '';
     render();
+    filterByRange('3m');
   } catch (err) {
     console.error(err);
     statusEl.textContent = 'Failed to load sold items.';

--- a/sold.html
+++ b/sold.html
@@ -51,6 +51,12 @@
       <p id="avg-price"></p>
       <ul id="monthly-sales"></ul>
     </div>
+    <div class="range-buttons" role="group" aria-label="Chart range">
+      <button id="range-1m" type="button">1M</button>
+      <button id="range-3m" type="button" class="active">3M</button>
+      <button id="range-6m" type="button">6M</button>
+      <button id="range-1y" type="button">1Y</button>
+    </div>
     <canvas id="sales-chart" aria-label="Sales chart" role="img"></canvas>
     <div class="table-container">
       <table id="sold-table" aria-labelledby="sold-table-caption">
@@ -78,6 +84,6 @@
   <script src="main.js" defer></script>
   <script src="page-transitions.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-  <script type="module" src="scripts/sold.js"></script>
+  <script src="scripts/sold.js" defer></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -267,6 +267,23 @@ select:focus-visible {
   max-height:calc(100vh - var(--navbar-height));
   overflow:hidden;
 }
+.range-buttons{
+  display:flex;
+  gap:.5rem;
+  margin-top:.5rem;
+}
+.range-buttons button{
+  padding:.3rem .6rem;
+  background:var(--color-primary);
+  color:var(--white);
+  border:none;
+  border-radius:.3rem;
+  cursor:pointer;
+}
+.range-buttons button.active{
+  background:var(--color-accent);
+  color:var(--black);
+}
 .sold-page .table-container{
   overflow-x:auto;
   overflow-y:auto;

--- a/tests/sold.spec.ts
+++ b/tests/sold.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const filePath = path.resolve(__dirname, '../sold.html');
 
-test('sold page defaults to last 90 days and shows platform column', async ({ page }) => {
+test('sold page defaults to last 90 days and 3 month range, allows range change', async ({ page }) => {
   await page.addInitScript(() => {
     const originalFetch = window.fetch;
     window.fetch = (url, options) => {
@@ -29,5 +29,8 @@ test('sold page defaults to last 90 days and shows platform column', async ({ pa
   await page.evaluate(() => (document as any).fonts.ready);
 
   await expect(page.locator('#date-filter')).toHaveValue('90');
+  await expect(page.locator('#range-3m')).toHaveClass(/active/);
+  await page.click('#range-1m');
+  await expect(page.locator('#range-1m')).toHaveClass(/active/);
   await expect(page.locator('#sold-table thead th').nth(3)).toHaveText('Platform');
 });


### PR DESCRIPTION
## Summary
- add 1M/3M/6M/1Y range buttons to sold listings chart and load script with `defer`
- implement `filterByRange` helper and button listeners to update chart
- style range buttons with clear active state
- test default range and range change

## Testing
- `npm test tests/sold.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a66d0f44bc832c9877239ec4e703b2