### PR TITLE
Add three month sales snapshot

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -6,6 +6,7 @@ const dateFilterEl = document.getElementById('date-filter');
 const chartCanvas = document.getElementById('sales-chart');
 const pricePointsEl = document.getElementById('price-points');
 const conditionTableBody = document.querySelector('#condition-comparison tbody');
+const snapshotEl = document.getElementById('three-month-snapshot');
 chartCanvas.height = 300;
 const chartCtx = chartCanvas.getContext('2d');
 let rangeButtons;
@@ -296,6 +297,47 @@ function updatePricePoints(items, listings = [], quantity = null, sellers = null
   });
 }
 
+function updateSnapshot(items) {
+  if (!snapshotEl) return;
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 90);
+
+  const recent = items.filter(item => {
+    const date = item.date ? new Date(item.date) : null;
+    return date && !isNaN(date) && date >= cutoff;
+  });
+
+  const prices = recent
+    .map(item => parsePrice(item.price))
+    .filter(n => !isNaN(n));
+
+  const low = prices.length ? Math.min(...prices) : null;
+  const high = prices.length ? Math.max(...prices) : null;
+  const total = recent.length;
+
+  snapshotEl.innerHTML = '';
+  const metrics = [
+    { label: 'Low Price', value: low != null ? `$${low.toFixed(2)}` : 'N/A' },
+    {
+      label: 'High Sale Price',
+      value: high != null ? `$${high.toFixed(2)}` : 'N/A'
+    },
+    { label: 'Total Sold', value: String(total) }
+  ];
+
+  metrics.forEach(m => {
+    const card = document.createElement('div');
+    card.className = 'snapshot-card';
+    const h3 = document.createElement('h3');
+    h3.textContent = m.label;
+    const p = document.createElement('p');
+    p.textContent = m.value;
+    card.append(h3, p);
+    snapshotEl.appendChild(card);
+  });
+}
+
 function render() {
   const filtered = filterItems(allItems);
   renderTable(filtered);
@@ -347,6 +389,7 @@ async function loadSoldItems() {
     render();
     filterByRange('3m');
     updatePricePoints(allItems, listings, qty, sellerCount);
+    updateSnapshot(allItems);
   } catch (err) {
     console.error(err);
     statusEl.textContent = 'Failed to load sold items.';

--- a/sold.html
+++ b/sold.html
@@ -51,6 +51,7 @@
       <p id="avg-price"></p>
       <ul id="monthly-sales"></ul>
     </div>
+    <section id="three-month-snapshot" aria-label="Three month snapshot"></section>
     <div class="range-buttons" role="group" aria-label="Chart range">
       <button id="range-1m" type="button">1M</button>
       <button id="range-3m" type="button" class="active">3M</button>

--- a/style.css
+++ b/style.css
@@ -321,14 +321,14 @@ select:focus-visible {
   flex:0 0 auto;
 }
 
-#price-points{
+#price-points,#three-month-snapshot{
   display:grid;
   grid-template-columns:repeat(auto-fit,minmax(140px,1fr));
   gap:1rem;
   margin-top:1rem;
 }
 
-.price-card{
+.price-card,.snapshot-card{
   background:rgba(255,255,255,.08);
   border:1px solid rgba(255,255,255,.2);
   border-radius:.5rem;
@@ -336,13 +336,13 @@ select:focus-visible {
   text-align:center;
 }
 
-.price-card h3{
+.price-card h3,.snapshot-card h3{
   margin-bottom:.25rem;
   font-size:1rem;
   color:var(--color-accent);
 }
 
-.price-card p{
+.price-card p,.snapshot-card p{
   margin:0;
   font-weight:600;
 }

--- a/tests/sold.spec.ts
+++ b/tests/sold.spec.ts
@@ -86,3 +86,43 @@ test('renders price points when data available', async ({ page }) => {
   await expect(row.locator('td').nth(0)).toHaveText('Near Mint');
   await expect(row.locator('td').nth(1)).toHaveText('$90.00');
 });
+
+test('three month snapshot reflects recent sales', async ({ page }) => {
+  await page.addInitScript(() => {
+    const sample = [
+      { title: 'A', price: { value: 20, currency: 'USD' }, date: '2099-05-20' },
+      { title: 'B', price: { value: 10, currency: 'USD' }, date: '2099-05-10' },
+      { title: 'C', price: { value: 5, currency: 'USD' }, date: '2000-01-01' }
+    ];
+    const originalFetch = window.fetch;
+    window.fetch = (url, options) => {
+      if (typeof url === 'string' && url.endsWith('sold-items.json')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(sample), {
+            headers: { 'Content-Type': 'application/json' }
+          })
+        );
+      }
+      return originalFetch(url, options);
+    };
+    window.Chart = function () {
+      return {
+        data: { labels: [], datasets: [{ data: [] }] },
+        update() {},
+        destroy() {},
+      };
+    };
+  });
+
+  await page.goto('file://' + filePath);
+  await page.evaluate(() => (document as any).fonts.ready);
+
+  const cards = page.locator('#three-month-snapshot .snapshot-card');
+  await expect(cards).toHaveCount(3);
+  await expect(cards.nth(0).locator('h3')).toHaveText('Low Price');
+  await expect(cards.nth(0).locator('p')).toHaveText('$10.00');
+  await expect(cards.nth(1).locator('h3')).toHaveText('High Sale Price');
+  await expect(cards.nth(1).locator('p')).toHaveText('$20.00');
+  await expect(cards.nth(2).locator('h3')).toHaveText('Total Sold');
+  await expect(cards.nth(2).locator('p')).toHaveText('2');
+});


### PR DESCRIPTION
## Summary
- add three month snapshot section on sold page
- compute low price, high sale price, and total sold in last 90 days
- style and test snapshot metrics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67ab62fa8832cb34b5b11253b1ab9