### PR TITLE
Add skip links and main landmarks for accessibility

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -21,6 +21,7 @@
   <meta property="og:url" content="https://heccollects.github.io/faq.html">
 </head>
 <body class="faq-page">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="navbar">
     <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
@@ -43,7 +44,7 @@
       <span class="line" aria-hidden="true"></span>
     </button>
   </header>
-  <main class="policy-content">
+  <main id="main" class="policy-content">
     <h1>Frequently Asked Questions</h1>
     <details id="orders-shipping">
       <summary aria-expanded="false">Orders & Shipping</summary>

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
     <meta name="apple-mobile-web-app-title" content="HecCollects">
   </head>
 <body>
+    <a class="skip-link" href="#main">Skip to content</a>
     <noscript><p>Please enable JavaScript to browse HecCollects.</p></noscript>
     <div id="preloader"><div class="dotted-loader"></div></div>
   <!-- Navbar -->
@@ -182,7 +183,7 @@
   </form>
 
   <!-- Sections -->
-  <main>
+  <main id="main">
     <!-- HOME -->
     <section id="home">
       <div class="section-content">

--- a/privacy.html
+++ b/privacy.html
@@ -61,6 +61,7 @@
     </script>
 </head>
 <body class="privacy-page">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="navbar">
     <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
@@ -83,7 +84,7 @@
       <span class="line" aria-hidden="true"></span>
     </button>
   </header>
-  <main class="policy-content">
+  <main id="main" class="policy-content">
     <h1>Privacy Policy</h1>
     <details id="information-we-collect">
       <summary aria-expanded="false">Information We Collect</summary>

--- a/returns.html
+++ b/returns.html
@@ -21,6 +21,7 @@
   <meta property="og:url" content="https://heccollects.github.io/returns.html">
 </head>
 <body class="returns-page">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="navbar">
     <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
@@ -43,7 +44,7 @@
       <span class="line" aria-hidden="true"></span>
     </button>
   </header>
-  <main class="policy-content">
+  <main id="main" class="policy-content">
     <h1>Shipping &amp; Returns</h1>
     <details id="shipping-policy">
       <summary aria-expanded="false">Shipping Policy</summary>

--- a/sold.html
+++ b/sold.html
@@ -14,6 +14,7 @@
   <script src="analytics.js" defer></script>
 </head>
 <body class="sold-page">
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="navbar">
     <a href="index.html#home" class="brand">
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
@@ -36,7 +37,7 @@
       <span class="line" aria-hidden="true"></span>
     </button>
   </header>
-  <main class="policy-content">
+  <main id="main" class="policy-content">
     <h1>Sold Listings</h1>
     <p id="sold-status" role="status"></p>
     <div class="controls">

--- a/style.css
+++ b/style.css
@@ -24,6 +24,9 @@ section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z
 .hidden{display:none!important}
 /* Screen reader only */
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);clip-path:inset(50%);white-space:nowrap;border:0}
+/* Skip link */
+.skip-link{position:absolute;top:-40px;left:0;padding:.5rem 1rem;background:var(--color-accent);color:var(--black);text-decoration:none;z-index:100}
+.skip-link:focus{top:0}
 /* ---------- Typography ---------- */
 .logo{width:100px;height:100px;border-radius:50%;object-fit:cover;box-shadow:0 6px 14px rgba(0,0,0,.5)}
 h1{font-size:2.4rem;text-shadow:0 3px 8px rgba(0,0,0,.4)}


### PR DESCRIPTION
## Summary
- add visible-on-focus skip links to all top-level pages
- mark primary content with `id="main"`
- style skip links for off-screen positioning until focused

## Testing
- `npm test` *(fails: 11 failed, 83 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d5447440832cabd63b6c1bfdab8a