### PR TITLE
Provide table of contents on policy pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -46,6 +46,15 @@
   </header>
   <main id="main" class="policy-content">
     <h1>Frequently Asked Questions</h1>
+    <nav class="toc" aria-label="Table of contents">
+      <ol>
+        <li><a href="#orders-shipping">Orders &amp; Shipping</a></li>
+        <li><a href="#returns-refunds">Returns &amp; Refunds</a></li>
+        <li><a href="#customer-support">Customer Support</a></li>
+        <li><a href="#payments-pricing">Payments &amp; Pricing</a></li>
+        <li><a href="#product-information">Product Information</a></li>
+      </ol>
+    </nav>
     <details id="orders-shipping">
       <summary aria-expanded="false">Orders & Shipping</summary>
       <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -86,6 +86,18 @@
   </header>
   <main id="main" class="policy-content">
     <h1>Privacy Policy</h1>
+    <nav class="toc" aria-label="Table of contents">
+      <ol>
+        <li><a href="#information-we-collect">Information We Collect</a></li>
+        <li><a href="#how-we-use-information">How We Use Information</a></li>
+        <li><a href="#cookie-usage">Cookie Usage</a></li>
+        <li><a href="#analytics-tools">Analytics Tools</a></li>
+        <li><a href="#data-sharing">Data Sharing</a></li>
+        <li><a href="#opt-out-options">Opt-Out Options</a></li>
+        <li><a href="#data-retention">Data Retention</a></li>
+        <li><a href="#your-rights-and-data-requests">Your Rights and Data Requests</a></li>
+      </ol>
+    </nav>
     <details id="information-we-collect">
       <summary aria-expanded="false">Information We Collect</summary>
       <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>

--- a/returns.html
+++ b/returns.html
@@ -46,6 +46,15 @@
   </header>
   <main id="main" class="policy-content">
     <h1>Shipping &amp; Returns</h1>
+    <nav class="toc" aria-label="Table of contents">
+      <ol>
+        <li><a href="#shipping-policy">Shipping Policy</a></li>
+        <li><a href="#returns-policy">Returns Policy</a></li>
+        <li><a href="#refund-exceptions">Refund Exceptions</a></li>
+        <li><a href="#customer-rights">Customer Rights</a></li>
+        <li><a href="#communication-expectations">Communication Expectations</a></li>
+      </ol>
+    </nav>
     <details id="shipping-policy">
       <summary aria-expanded="false">Shipping Policy</summary>
       <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>

--- a/sold.html
+++ b/sold.html
@@ -39,6 +39,16 @@
   </header>
   <main id="main" class="policy-content">
     <h1>Sold Listings</h1>
+    <nav class="toc" aria-label="Table of contents">
+      <ol>
+        <li><a href="#summary">Summary</a></li>
+        <li><a href="#sales-chart">Sales Chart</a></li>
+        <li><a href="#price-points">Price Points</a></li>
+        <li><a href="#condition-comparison">Condition Comparison</a></li>
+        <li><a href="#three-month-snapshot">Three Month Snapshot</a></li>
+        <li><a href="#sold-table">Sold Items</a></li>
+      </ol>
+    </nav>
     <p id="sold-status" role="status"></p>
     <div class="controls">
       <label for="date-filter">Date Range:</label>


### PR DESCRIPTION
## Summary
- Add in-page table of contents navigation to FAQ, Returns, Privacy, and Sold Listings pages
- Ensure TOC links reference unique section IDs for keyboard accessibility

## Testing
- `npm test` *(failed: Operation was interrupted before it could finish)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e63291c0832c9d854d88a25910dd