### PR TITLE
feat: add back-to-top button

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -131,6 +131,7 @@
     ]
   }
   </script>
+  <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>
   <script src="main.js" defer></script>
   <script src="page-transitions.js" defer></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
     <span>This site uses cookies and analytics to improve your experience.</span>
     <button id="cookie-btn">OK</button>
   </div>
-
+  <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>
   <!-- ---------- JS: interactions & animations ---------- -->
     <script src="vendor/three.min.js" defer></script>
     <script src="vendor/vanta.net.min.js" defer></script>

--- a/main.js
+++ b/main.js
@@ -690,6 +690,22 @@
     });
   }
 
+  const backToTop = document.getElementById('back-to-top');
+  if (backToTop) {
+    const toggleBackToTop = () => {
+      if (window.scrollY > 300) {
+        backToTop.classList.add('show');
+      } else {
+        backToTop.classList.remove('show');
+      }
+    };
+    window.addEventListener('scroll', toggleBackToTop);
+    toggleBackToTop();
+    backToTop.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
   // Cookie/analytics notice
   const cookieBanner = document.getElementById('cookie-banner');
   const cookieBtn = document.getElementById('cookie-btn');

--- a/privacy.html
+++ b/privacy.html
@@ -138,6 +138,7 @@
     <a href="returns.html">Returns</a>
     <a href="privacy.html">Privacy Policy</a>
   </footer>
+  <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>
   <script src="main.js" defer></script>
   <script src="page-transitions.js" defer></script>
 </body>

--- a/returns.html
+++ b/returns.html
@@ -103,6 +103,7 @@
     "applicableCountry": "US"
   }
   </script>
+  <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>
   <script src="main.js" defer></script>
   <script src="page-transitions.js" defer></script>
 </body>

--- a/sold.html
+++ b/sold.html
@@ -97,6 +97,7 @@
     <a href="returns.html">Returns</a>
     <a href="privacy.html">Privacy Policy</a>
   </footer>
+  <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>
   <script src="main.js" defer></script>
   <script src="page-transitions.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>

--- a/style.css
+++ b/style.css
@@ -344,3 +344,5 @@ select:focus-visible {
 
 #sold-table th[aria-sort='ascending']::after{content:'\25B2';margin-left:.25rem;}
 #sold-table th[aria-sort='descending']::after{content:'\25BC';margin-left:.25rem;}
+.back-to-top{position:fixed;bottom:1.5rem;right:1.5rem;display:none;background:var(--color-accent);color:var(--black);border:none;border-radius:50%;width:2.5rem;height:2.5rem;font-size:1.2rem;cursor:pointer;z-index:1000}
+.back-to-top.show{display:flex;align-items:center;justify-content:center}


### PR DESCRIPTION
## Summary
- Add a reusable back-to-top button to all pages
- Style the button and keep it hidden until scrolled
- Toggle button visibility with JavaScript and enable smooth scrolling

## Testing
- `npm test` *(fails: sold page tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f657ad0832c8ccf82bc37fd065c