### PR TITLE
Add skeleton loaders for sold listings

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -9,6 +9,9 @@ const conditionComparisonEl = document.getElementById('condition-comparison');
 const searchEl = document.getElementById('sold-search');
 const tableHeaders = document.querySelectorAll('#sold-table thead th');
 const snapshotEl = document.getElementById('three-month-snapshot');
+const tableEl = document.getElementById('sold-table');
+const skeletonChart = document.querySelector('.skeleton-chart');
+const skeletonTable = document.querySelector('.skeleton-table');
 chartCanvas.height = 300;
 const chartCtx = chartCanvas.getContext('2d');
 let rangeButtons;
@@ -454,6 +457,10 @@ async function loadSoldItems() {
       condition: item.condition || ''
     }));
     statusEl.textContent = '';
+    skeletonChart?.classList.add('hidden');
+    skeletonTable?.classList.add('hidden');
+    chartCanvas.classList.remove('hidden');
+    tableEl.classList.remove('hidden');
     render();
     filterByRange('3m');
     updatePricePoints(allItems, listings, qty, sellerCount);
@@ -461,6 +468,8 @@ async function loadSoldItems() {
   } catch (err) {
     console.error(err);
     statusEl.textContent = 'Failed to load sold items.';
+    skeletonChart?.classList.add('hidden');
+    skeletonTable?.classList.add('hidden');
   }
 }
 

--- a/sold.html
+++ b/sold.html
@@ -71,12 +71,14 @@
       <button id="range-6m" type="button">6M</button>
       <button id="range-1y" type="button">1Y</button>
     </div>
-    <canvas id="sales-chart" aria-label="Sales chart" role="img"></canvas>
+    <div class="skeleton-chart"></div>
+    <canvas id="sales-chart" aria-label="Sales chart" role="img" class="hidden"></canvas>
     <section id="price-points" aria-label="Price points"></section>
     <section id="condition-comparison" aria-label="Condition comparison"></section>
     <section id="three-month-snapshot" aria-label="Three month snapshot"></section>
     <div class="table-container">
-      <table id="sold-table" aria-labelledby="sold-table-caption">
+      <div class="skeleton-table"></div>
+      <table id="sold-table" aria-labelledby="sold-table-caption" class="hidden">
         <caption id="sold-table-caption">Sold items with prices, dates, platforms, and locations</caption>
         <thead>
           <tr>

--- a/style.css
+++ b/style.css
@@ -311,6 +311,16 @@ select:focus-visible {
   margin-top:1rem;
   flex:0 0 auto;
 }
+.skeleton-chart,.skeleton-table{
+  width:100%;
+  background:linear-gradient(90deg,rgba(255,255,255,.1),rgba(255,255,255,.3),rgba(255,255,255,.1));
+  background-size:200% 100%;
+  animation:shimmer 1.5s infinite;
+  border-radius:.5rem;
+}
+.skeleton-chart{height:300px;margin-top:1rem;}
+.skeleton-table{height:200px;margin-top:1rem;}
+@keyframes shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
 
 #price-points,#condition-comparison,#three-month-snapshot{
   display:grid;


### PR DESCRIPTION
## Summary
- add skeleton placeholders for sales chart and table
- style skeleton loaders with animated shimmer effect
- hide skeletons and reveal content once sold data loads

## Testing
- `npm test` *(fails: 1 interrupted, 89 did not run, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a896cd2614832cb6accdf1efbf3b98