### PR TITLE
Allow HTTPS image sources in sold page CSP

### DIFF
--- a/sold.html
+++ b/sold.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Sold Listings - HecCollects</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>


### PR DESCRIPTION
## Summary
- permit images from any HTTPS source in sold page CSP to support external thumbnails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bdff910832c999bdaaf28785923