### PR TITLE
Add sitemap and robots directives

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://heccollects.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://heccollects.github.io/</loc>
+  </url>
+  <url>
+    <loc>https://heccollects.github.io/sold.html</loc>
+  </url>
+  <url>
+    <loc>https://heccollects.github.io/faq.html</loc>
+  </url>
+  <url>
+    <loc>https://heccollects.github.io/returns.html</loc>
+  </url>
+  <url>
+    <loc>https://heccollects.github.io/privacy.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add sitemap listing key site pages for search engines
- configure robots.txt to expose sitemap

## Testing
- `npm install`
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8ae4dbe8832cab56d1b33d80a44a