### PR TITLE
Relocate testimonial carousel and update headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
     </a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-        <a href="#testimonials">Testimonials</a>
+        <a href="#testimonials">Success Stories</a>
         <a href="#why">Why</a>
         <a href="#how">How</a>
       <a href="#ebay">eBay</a>
@@ -205,11 +205,40 @@
       </div>
     </section>
 
+      <!-- WHY -->
+      <section id="why">
+        <div class="section-content">
+          <div class="card reveal">
+            <h2 id="why-heccollects">Why HecCollects?</h2>
+            <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and how they compare within their respective hobbies. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- HOW -->
+      <section id="how">
+        <div class="section-content">
+          <div class="card reveal">
+            <h2 id="how-it-works">How HecCollects Earns Trust &amp; Ensures Success</h2>
+            <ul class="how-list">
+              <li><strong>Fast Shipping:</strong> Orders ship within 1 business day.</li>
+              <li><strong>Fair Pricing:</strong> Listings are just under market to keep collecting accessible.</li>
+              <li><strong>Secure Transactions:</strong> Payments are protected from checkout to delivery.</li>
+            </ul>
+            <div class="trust-badges">
+              <span class="badge"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Secure Transactions</span>
+              <span class="badge"><i class="fa-solid fa-award" aria-hidden="true"></i> Top Rated Seller</span>
+              <span class="badge"><i class="fa-solid fa-thumbs-up" aria-hidden="true"></i> 100% Positive Feedback</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- TESTIMONIALS -->
       <section id="testimonials">
       <div class="section-content">
         <div class="card reveal">
-          <h2>Testimonials</h2>
+          <h2>Collector Success Stories</h2>
           <p>What collectors and clients are saying:</p>
           <div class="testimonials" aria-live="polite">
             <div class="testimonial-track">
@@ -245,35 +274,6 @@
       </div>
       </section>
 
-      <!-- WHY -->
-      <section id="why">
-        <div class="section-content">
-          <div class="card reveal">
-            <h2 id="why-heccollects">Why HecCollects?</h2>
-            <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and how they compare within their respective hobbies. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
-          </div>
-        </div>
-      </section>
-
-      <!-- HOW -->
-      <section id="how">
-        <div class="section-content">
-          <div class="card reveal">
-            <h2 id="how-it-works">How It Works</h2>
-            <ul class="how-list">
-              <li><strong>Fast Shipping:</strong> Orders ship within 1 business day.</li>
-              <li><strong>Fair Pricing:</strong> Listings are just under market to keep collecting accessible.</li>
-              <li><strong>Secure Transactions:</strong> Payments are protected from checkout to delivery.</li>
-            </ul>
-            <div class="trust-badges">
-              <span class="badge"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Secure Transactions</span>
-              <span class="badge"><i class="fa-solid fa-award" aria-hidden="true"></i> Top Rated Seller</span>
-              <span class="badge"><i class="fa-solid fa-thumbs-up" aria-hidden="true"></i> 100% Positive Feedback</span>
-            </div>
-          </div>
-        </div>
-      </section>
-
       <!-- EBAY -->
       <section id="ebay">
       <div class="section-content">
@@ -284,7 +284,7 @@
             <a href="https://ebay.us/m/HoUY1I" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay"><i class="fa-brands fa-ebay" aria-hidden="true"></i> Visit eBay Store</a>
           </div>
           <div class="featured">
-            <h3>Featured Items</h3>
+            <h3>Collector Favorites</h3>
             <div class="carousel">
               <button class="carousel-btn carousel-prev" aria-label="Previous"><i class="fa-solid fa-chevron-left" aria-hidden="true"></i></button>
               <div class="featured-items" id="ebay-items"></div>
@@ -306,7 +306,7 @@
             <a href="https://offerup.co/xluJorjDIVb" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup"><i class="fa-solid fa-store" aria-hidden="true"></i> Visit OfferUp</a>
           </div>
           <div class="featured">
-            <h3>Featured Items</h3>
+            <h3>Collector Favorites</h3>
             <div class="carousel">
               <button class="carousel-btn carousel-prev" aria-label="Previous"><i class="fa-solid fa-chevron-left" aria-hidden="true"></i></button>
               <div class="featured-items" id="offerup-items"></div>

--- a/main.js
+++ b/main.js
@@ -394,7 +394,7 @@
   }
 
   // Testimonials slider
-  const testimonialWrapper = document.querySelector('.testimonials');
+  const testimonialWrapper = document.querySelector('#testimonials .testimonials');
   if (testimonialWrapper) {
     const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
     const track = testimonialWrapper.querySelector('.testimonial-track');

--- a/tests/navbar-links.spec.ts
+++ b/tests/navbar-links.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const filePath = path.resolve(__dirname, '../index.html');
 
-const expected = ['Testimonials', 'Why', 'How', 'eBay', 'OfferUp', 'Subscribe', 'Business Inquiries'];
+const expected = ['Success Stories', 'Why', 'How', 'eBay', 'OfferUp', 'Subscribe', 'Business Inquiries'];
 
 test('navbar links are in expected order', async ({ page }) => {
   await page.goto('file://' + filePath);


### PR DESCRIPTION
## Summary
- Move testimonial carousel to follow the "How" section and retitle it "Collector Success Stories"
- Emphasize trust and success in "How" section header and feature carousels as "Collector Favorites"
- Update navbar link expectations in tests and target testimonial carousel via section ID in scripts

## Testing
- `npx playwright test tests/navbar-links.spec.ts`
- `npx playwright test tests/sections.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aba893aec8832c93a450f9450e213d