### PR TITLE
Refactor story and trust sections with animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,8 +158,8 @@
     </a>
     <nav id="nav-menu" class="nav-menu" aria-hidden="true">
         <a href="#testimonials">Success Stories</a>
-        <a href="#why">Why</a>
-        <a href="#how">How</a>
+        <a href="#story">Our Story</a>
+        <a href="#approach">Built on Trust</a>
       <a href="#ebay">eBay</a>
       <a href="#offerup">OfferUp</a>
       <a href="#subscribe">Subscribe</a>
@@ -212,21 +212,21 @@
       </div>
     </section>
 
-      <!-- WHY -->
-      <section id="why">
+      <!-- OUR STORY -->
+      <section id="story">
         <div class="section-content">
           <div class="card reveal">
-            <h2 id="why-heccollects">Why HecCollects?</h2>
+            <h2 id="our-story">Our Story</h2>
             <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and how they compare within their respective hobbies. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
           </div>
         </div>
       </section>
 
-      <!-- HOW -->
-      <section id="how">
+      <!-- BUILT ON TRUST -->
+      <section id="approach">
         <div class="section-content">
           <div class="card reveal">
-            <h2 id="how-it-works">How HecCollects Earns Trust &amp; Ensures Success</h2>
+            <h2 id="built-on-trust">Built on Trust</h2>
             <ul class="how-list">
               <li><strong>Fast Shipping:</strong> Orders ship within 1 business day.</li>
               <li><strong>Fair Pricing:</strong> Listings are just under market to keep collecting accessible.</li>

--- a/main.js
+++ b/main.js
@@ -279,6 +279,17 @@
             link.removeAttribute('aria-current');
           }
         });
+        if(entry.target.id === 'story'){
+          entry.target.classList.add('story-bg-animate');
+        } else if(entry.target.id === 'approach'){
+          entry.target.classList.add('approach-bg-animate');
+        }
+      } else {
+        if(entry.target.id === 'story'){
+          entry.target.classList.remove('story-bg-animate');
+        } else if(entry.target.id === 'approach'){
+          entry.target.classList.remove('approach-bg-animate');
+        }
       }
     });
   }, { threshold:0.6 });

--- a/style.css
+++ b/style.css
@@ -14,9 +14,9 @@ body{font-family:'Poppins',sans-serif;background:linear-gradient(135deg,var(--bl
 /* ---------- Sections ---------- */
 section{position:relative;height:100dvh;min-height:100dvh;scroll-snap-align:start;display:flex;align-items:center;justify-content:center;text-align:center;background-position:center 20%;background-size:cover;background-repeat:no-repeat;background-attachment:scroll}
 section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z-index:0}
-.section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2.5rem calc(env(safe-area-inset-right) + 2.5rem) 2.5rem calc(env(safe-area-inset-left) + 2.5rem)}
+.section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2.5rem calc(env(safe-area-inset-right) + 2.5rem) 2.5rem calc(env(safe-area-inset-left) + 2.5rem)}@media(prefers-reduced-motion:no-preference){.story-bg-animate,.approach-bg-animate{background-size:200% 200%;animation:bg-shift 15s ease infinite}.approach-bg-animate{animation-direction:reverse}}
 /* ---------- Card ---------- */
- .card{background:rgba(255,255,255,.08);backdrop-filter:blur(8px);border:2px solid rgba(255,255,255,.18);border-radius:1.6rem;padding:2rem 2rem;width:100%;max-width:460px;box-shadow:0 25px 50px rgba(0,0,0,.35);transition:transform .45s cubic-bezier(.34,1.56,.64,1);display:flex;flex-direction:column;align-items:center;gap:1.4rem}
+ .card{background:rgba(255,255,255,.08);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border:2px solid rgba(255,255,255,.18);border-radius:1.6rem;padding:2rem 2rem;width:100%;max-width:460px;box-shadow:0 25px 50px rgba(0,0,0,.35);transition:transform .45s cubic-bezier(.34,1.56,.64,1);display:flex;flex-direction:column;align-items:center;gap:1.4rem}
 .card:hover{transform:translateY(-10px) rotateX(5deg) rotateY(-5deg)}
 .tilt:hover{transform:none}
 .reveal{opacity:0;transform:translateY(40px);transition:opacity .6s ease-out,transform .6s ease-out}
@@ -91,12 +91,12 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
 .trust-badges{display:flex;gap:.5rem;justify-content:center;margin-top:1rem;flex-wrap:wrap}
 .trust-badges .badge{display:flex;align-items:center;gap:.3rem;border:1px solid var(--color-accent);border-radius:.4rem;padding:.25rem .5rem;font-size:.8rem}
 .trust-badges .badge i{color:var(--color-accent)}
-/* Why and How blocks */
-#why .card{border-left:4px solid var(--color-accent)}
-#how .card{border-left:4px solid var(--color-secondary)}
-#how .how-list{list-style:none;margin:0;padding:0;text-align:left}
-#how .how-list li{margin-bottom:.5rem}
-#how .how-list li strong{color:var(--color-accent)}
+/* Story and Approach blocks */
+#story .card{border-inline-start:4px solid var(--color-accent)}
+#approach .card{border-inline-start:4px solid var(--color-secondary)}
+#approach .how-list{list-style:none;margin:0;padding:0;text-align:left}
+#approach .how-list li{margin-bottom:.5rem}
+#approach .how-list li strong{color:var(--color-accent)}
 /* Product search */
 #search-form{position:relative;width:min(90%,480px);margin:1rem auto;padding-left:env(safe-area-inset-left);padding-right:env(safe-area-inset-right)}
 #product-search{width:100%;padding:.8rem 1rem;border:2px solid var(--color-accent);border-radius:.6rem;background:rgba(255,255,255,.1);color:var(--white)}
@@ -137,7 +137,7 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
     calc(env(safe-area-inset-right)+1.5rem)
     .7rem
     calc(env(safe-area-inset-left)+1.5rem);
-    display:flex;justify-content:space-between;align-items:center;background:rgba(0,0,0,.45);backdrop-filter:blur(6px);z-index:10000;box-shadow:0 4px 12px rgba(0,0,0,.3)}
+    display:flex;justify-content:space-between;align-items:center;background:rgba(0,0,0,.45);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);z-index:10000;box-shadow:0 4px 12px rgba(0,0,0,.3)}
 .brand{font-size:1.3rem;font-weight:700;text-decoration:none;color:inherit}
 .nav-toggle{width:32px;height:24px;display:flex;flex-direction:column;justify-content:space-between;background:none;border:none;cursor:pointer;z-index:10001}
 .line{width:100%;height:3px;background:var(--white);border-radius:2px;transition:transform .3s,opacity .3s}
@@ -169,7 +169,7 @@ section{background-attachment:fixed}
 }
 @media(min-width:1024px){
   .nav-toggle{display:none}
-  .nav-menu{position:static;transform:none;opacity:1;pointer-events:auto;flex-direction:row;gap:2rem;background:none;backdrop-filter:none;box-shadow:none;height:auto}
+  .nav-menu{position:static;transform:none;opacity:1;pointer-events:auto;flex-direction:row;gap:2rem;background:none;backdrop-filter:none;-webkit-backdrop-filter:none;box-shadow:none;height:auto}
   .nav-menu a{font-size:1rem}
   .card{max-width:900px;padding:3rem 4rem}
   .featured-items{gap:1rem;justify-content:flex-start;padding-inline:calc((100% - 250px)/2);scroll-padding-inline:calc((100% - 250px)/2)}
@@ -178,6 +178,8 @@ section{background-attachment:fixed}
 
 /* ---------- Background Images ---------- */
 #home{position:relative;overflow:hidden;background-image:linear-gradient(135deg,var(--color-primary),var(--color-secondary))}
+#story{background-image:linear-gradient(135deg,var(--color-primary),var(--color-accent))}
+#approach{background-image:linear-gradient(135deg,var(--color-secondary),var(--color-primary))}
 #ebay{background-image:linear-gradient(135deg,var(--color-secondary),var(--color-accent))}
 #offerup{background-image:linear-gradient(135deg,var(--color-accent),var(--color-primary))}
 #about{background-image:linear-gradient(135deg,var(--color-primary),var(--color-accent))}

--- a/tests/navbar-links.spec.ts
+++ b/tests/navbar-links.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const filePath = path.resolve(__dirname, '../index.html');
 
-const expected = ['Success Stories', 'Why', 'How', 'eBay', 'OfferUp', 'Subscribe', 'Business Inquiries'];
+const expected = ['Success Stories', 'Our Story', 'Built on Trust', 'eBay', 'OfferUp', 'Subscribe', 'Business Inquiries'];
 
 test('navbar links are in expected order', async ({ page }) => {
   await page.goto('file://' + filePath);

--- a/tests/scroll.spec.ts
+++ b/tests/scroll.spec.ts
@@ -5,7 +5,7 @@ test.use({ viewport: { width: 375, height: 667 } });
 
 const filePath = path.resolve(__dirname, '../index.html');
 
-const navTargets = ['#home', '#testimonials', '#why', '#how', '#ebay', '#offerup', '#subscribe', '#contact'];
+const navTargets = ['#home', '#testimonials', '#story', '#approach', '#ebay', '#offerup', '#subscribe', '#contact'];
 
 test('sections scroll into view correctly', async ({ page }) => {
   await page.goto('file://' + filePath);

--- a/tests/sections.spec.ts
+++ b/tests/sections.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import path from 'path';
 
 const filePath = path.resolve(__dirname, '../index.html');
-const sections = ['home', 'testimonials', 'why', 'how', 'ebay', 'offerup', 'subscribe', 'contact'];
+const sections = ['home', 'testimonials', 'story', 'approach', 'ebay', 'offerup', 'subscribe', 'contact'];
 
 for (const section of sections) {
   test(`section ${section} is visible`, async ({ page }) => {


### PR DESCRIPTION
## Summary
- Rename "Why" and "How" sections to "Our Story" and "Built on Trust" with new navigation anchors
- Add scroll-triggered gradient animations and reduced-motion fallbacks
- Use logical borders and WebKit-prefixed backdrop filters for better iOS support

## Testing
- `npm test` *(dependency installation did not complete; unable to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abc718eba4832c81bac823dd76b213