### PR TITLE
Load deployment IDs before config

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,10 +5,10 @@
   const clean = (val) => (val && !/^%[A-Z_]+%$/.test(val)) ? val : '';
   const { gaId = '', recaptchaSiteKey = '', phoneNumber = '' } = script ? script.dataset : {};
 
-  window.GA_ID = window.GA_ID || clean(gaId);
+  window.GA_ID = clean(window.GA_ID || gaId);
   // reCAPTCHA site key. Replace with a real key for production.
-  window.RECAPTCHA_SITE_KEY = window.RECAPTCHA_SITE_KEY || clean(recaptchaSiteKey);
+  window.RECAPTCHA_SITE_KEY = clean(window.RECAPTCHA_SITE_KEY || recaptchaSiteKey);
   // Leaving the key empty disables reCAPTCHA for tests or local builds.
   // Contact phone number without the tel: prefix. Inject via deployment environment or build-time replacement.
-  window.PHONE_NUMBER = window.PHONE_NUMBER || clean(phoneNumber);
+  window.PHONE_NUMBER = clean(window.PHONE_NUMBER || phoneNumber);
 })();

--- a/env.js
+++ b/env.js
@@ -1,0 +1,3 @@
+window.GA_ID = window.GA_ID || "%GA_ID%";
+window.RECAPTCHA_SITE_KEY = window.RECAPTCHA_SITE_KEY || "%RECAPTCHA_SITE_KEY%";
+window.PHONE_NUMBER = window.PHONE_NUMBER || "%PHONE_NUMBER%";

--- a/faq.html
+++ b/faq.html
@@ -9,7 +9,8 @@
   <title>FAQ - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
-  <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
+  <script src="env.js"></script>
+  <script src="config.js" defer></script>
   <script src="analytics.js" defer></script>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">

--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@
   <link rel="preload" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAn0B9gF0NQAAAABJRU5ErkJggg==" as="image">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="theme.css">
-    <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
+    <script src="env.js"></script>
+    <script src="config.js" defer></script>
     <script src="analytics.js" defer></script>
     <script src="recaptcha.js" defer></script>
     <script type="application/ld+json">

--- a/main.js
+++ b/main.js
@@ -32,13 +32,6 @@
     }
   }
 
-  if (!window.GA_ID) {
-    console.warn('window.GA_ID is not set; analytics will be disabled.');
-  }
-  if (!window.PHONE_NUMBER) {
-    console.warn('window.PHONE_NUMBER is not set; phone link will be hidden.');
-  }
-
   const phoneLink = document.getElementById('phone-link');
   if (phoneLink) {
     if (window.PHONE_NUMBER) {

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,8 @@
   <title>Privacy Policy - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
-  <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
+  <script src="env.js"></script>
+  <script src="config.js" defer></script>
   <script src="analytics.js" defer></script>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">

--- a/returns.html
+++ b/returns.html
@@ -9,7 +9,8 @@
   <title>Shipping & Returns - HecCollects</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
-  <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
+  <script src="env.js"></script>
+  <script src="config.js" defer></script>
   <script src="analytics.js" defer></script>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">

--- a/sold.html
+++ b/sold.html
@@ -10,7 +10,8 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
-  <script src="config.js" data-ga-id="%GA_ID%" data-recaptcha-site-key="%RECAPTCHA_SITE_KEY%" data-phone-number="%PHONE_NUMBER%" defer></script>
+  <script src="env.js"></script>
+  <script src="config.js" defer></script>
   <script src="analytics.js" defer></script>
   <meta name="description" content="Browse sold listings from HecCollects including prices, dates, platforms, and locations.">
   <link rel="canonical" href="https://heccollects.github.io/sold.html">


### PR DESCRIPTION
## Summary
- Inject GA ID, reCAPTCHA site key, and phone number via new `env.js` loaded before `config.js`
- Sanitize injected values in `config.js` and drop console warnings in `main.js`
- Reference `env.js` on all pages so globals are available when scripts run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd56dd8dc832c9e82cd058f182bb2