### PR TITLE
Hide phone link until configured

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@
           <div class="links">
             <a href="mailto:hectorsandoval1402@gmail.com" class="btn border-fade" data-analytics="email"><i class="fa-solid fa-envelope" aria-hidden="true"></i> Email Me</a>
             <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="instagram"><i class="fa-brands fa-instagram" aria-hidden="true"></i> Instagram</a>
-            <a id="phone-link" href="tel:" class="btn border-fade" data-analytics="phone"><i class="fa-solid fa-phone" aria-hidden="true"></i> Call Me</a>
+            <a id="phone-link" href="tel:" class="btn border-fade hidden" data-analytics="phone"><i class="fa-solid fa-phone" aria-hidden="true"></i> Call Me</a>
           </div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@
   if (phoneLink) {
     if (window.PHONE_NUMBER) {
       phoneLink.href = `tel:${window.PHONE_NUMBER}`;
+      phoneLink.classList.remove('hidden');
     } else {
       phoneLink.classList.add('hidden');
     }

--- a/tests/config-values.spec.ts
+++ b/tests/config-values.spec.ts
@@ -19,3 +19,10 @@ test('reCAPTCHA and phone link use provided window values', async ({ page }) => 
   await expect(phoneLink).toBeVisible();
   await expect(phoneLink).toHaveAttribute('href', 'tel:5551234');
 });
+
+test('phone link hidden when no phone number provided', async ({ page }) => {
+  await page.goto('file://' + filePath);
+
+  const phoneLink = page.locator('#phone-link');
+  await expect(phoneLink).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- Hide phone contact link by default
- Reveal phone link when a phone number is configured
- Test phone link behavior with and without number

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd8e9070c832c9ade897b3b10237f