### PR TITLE
Lazy-load hero animation and vendor scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,10 +381,9 @@
   </div>
   <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>
   <!-- ---------- JS: interactions & animations ---------- -->
-    <script src="vendor/three.min.js" defer></script>
-    <script src="vendor/vanta.net.min.js" defer></script>
     <script src="main.js" defer></script>
     <script src="page-transitions.js" defer></script>
     <script src="scripts/search.js" defer></script>
+    <script src="scripts/hero-loader.js" defer></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -486,11 +486,11 @@
 
     // Hero background animation
     const heroSection = document.getElementById('home');
-    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const heroMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
     let vantaEffect;
 
-    const initVanta = () => {
-      if (!heroSection || motionQuery.matches || !window.VANTA || !webglSupported) return;
+    window.initVanta = () => {
+      if (!heroSection || heroMotionQuery.matches || !window.VANTA || !webglSupported) return;
       vantaEffect = window.VANTA.NET({
         el: heroSection,
         mouseControls: false,
@@ -522,19 +522,13 @@
       if (e.matches) {
         destroyVanta();
       } else {
-        initVanta();
+        window.initVanta();
       }
     };
-    if (typeof motionQuery.addEventListener === 'function') {
-      motionQuery.addEventListener('change', handleMotionChange);
-    } else if (motionQuery.addListener) {
-      motionQuery.addListener(handleMotionChange);
-    }
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initVanta, { once: true });
-    } else {
-      initVanta();
+    if (typeof heroMotionQuery.addEventListener === 'function') {
+      heroMotionQuery.addEventListener('change', handleMotionChange);
+    } else if (heroMotionQuery.addListener) {
+      heroMotionQuery.addListener(handleMotionChange);
     }
 
     // 3D tilt on hero card
@@ -553,91 +547,92 @@
 
   // Package reveal animation
   const packageContainer = document.getElementById('package-anim');
-  if (packageContainer) {
+  window.initPackageAnimation = () => {
+    if (!packageContainer) return;
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const isLocal = window.location.protocol === 'file:';
     if (!webglSupported || !window.THREE || reduced || isLocal) {
       packageContainer.classList.add('show-logo');
-    } else {
-      let renderer, scene, camera, lid, logoMesh, animId, startTime, progress = 0;
-      const init = () => {
-        const { clientWidth: w, clientHeight: h } = packageContainer;
-        renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
-        renderer.setSize(w, h);
-        packageContainer.appendChild(renderer.domElement);
-        scene = new THREE.Scene();
-        camera = new THREE.PerspectiveCamera(45, w / h, 0.1, 100);
-        camera.position.set(0, 1.5, 4);
-        const material = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
-        const box = new THREE.Mesh(new THREE.BoxGeometry(2, 1, 2), material);
-        box.position.y = -0.5;
-        scene.add(box);
-        lid = new THREE.Mesh(new THREE.BoxGeometry(2, 0.1, 2), material);
-        lid.position.y = 0.05;
-        scene.add(lid);
-        const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
-        scene.add(light);
-        const loader = new THREE.TextureLoader();
-        const tex = loader.load('logo.png', undefined, undefined, () => {
-          packageContainer.classList.add('show-logo');
-          if (renderer && renderer.domElement) {
-            renderer.domElement.remove();
-          }
-        });
-        const plane = new THREE.PlaneGeometry(1.2, 1.2);
-        const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
-        logoMesh = new THREE.Mesh(plane, mat);
-        logoMesh.rotation.x = -Math.PI / 2;
-        logoMesh.position.y = -0.1;
-        logoMesh.visible = false;
-        scene.add(logoMesh);
-        renderer.render(scene, camera);
-      };
-      const step = (t) => {
-        if (!startTime) startTime = t;
-        const delta = t - startTime;
-        startTime = t;
-        progress = Math.min(progress + delta / 1000, 1);
-        lid.rotation.x = -Math.PI / 2 * progress;
-        if (progress >= 1) {
-          logoMesh.visible = true;
-          packageContainer.classList.add('show-logo');
-        }
-        renderer.render(scene, camera);
-        if (progress < 1) animId = requestAnimationFrame(step);
-        else animId = null;
-      };
-      const play = () => {
-        if (animId || progress >= 1) return;
-        startTime = null;
-        animId = requestAnimationFrame(step);
-      };
-      const pause = () => {
-        if (animId) {
-          cancelAnimationFrame(animId);
-          animId = null;
-        }
-      };
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            if (!renderer) init();
-            play();
-          } else {
-            pause();
-          }
-        });
-      }, { threshold: 0.5 });
-      observer.observe(packageContainer);
-      packageContainer.addEventListener('click', () => {
-        lid.rotation.x = 0;
-        logoMesh.visible = false;
-        packageContainer.classList.remove('show-logo');
-        progress = 0;
-        play();
-      });
+      return;
     }
-  }
+    let renderer, scene, camera, lid, logoMesh, animId, startTime, progress = 0;
+    const init = () => {
+      const { clientWidth: w, clientHeight: h } = packageContainer;
+      renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+      renderer.setSize(w, h);
+      packageContainer.appendChild(renderer.domElement);
+      scene = new THREE.Scene();
+      camera = new THREE.PerspectiveCamera(45, w / h, 0.1, 100);
+      camera.position.set(0, 1.5, 4);
+      const material = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
+      const box = new THREE.Mesh(new THREE.BoxGeometry(2, 1, 2), material);
+      box.position.y = -0.5;
+      scene.add(box);
+      lid = new THREE.Mesh(new THREE.BoxGeometry(2, 0.1, 2), material);
+      lid.position.y = 0.05;
+      scene.add(lid);
+      const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+      scene.add(light);
+      const loader = new THREE.TextureLoader();
+      const tex = loader.load('logo.png', undefined, undefined, () => {
+        packageContainer.classList.add('show-logo');
+        if (renderer && renderer.domElement) {
+          renderer.domElement.remove();
+        }
+      });
+      const plane = new THREE.PlaneGeometry(1.2, 1.2);
+      const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
+      logoMesh = new THREE.Mesh(plane, mat);
+      logoMesh.rotation.x = -Math.PI / 2;
+      logoMesh.position.y = -0.1;
+      logoMesh.visible = false;
+      scene.add(logoMesh);
+      renderer.render(scene, camera);
+    };
+    const step = (t) => {
+      if (!startTime) startTime = t;
+      const delta = t - startTime;
+      startTime = t;
+      progress = Math.min(progress + delta / 1000, 1);
+      lid.rotation.x = -Math.PI / 2 * progress;
+      if (progress >= 1) {
+        logoMesh.visible = true;
+        packageContainer.classList.add('show-logo');
+      }
+      renderer.render(scene, camera);
+      if (progress < 1) animId = requestAnimationFrame(step);
+      else animId = null;
+    };
+    const play = () => {
+      if (animId || progress >= 1) return;
+      startTime = null;
+      animId = requestAnimationFrame(step);
+    };
+    const pause = () => {
+      if (animId) {
+        cancelAnimationFrame(animId);
+        animId = null;
+      }
+    };
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          if (!renderer) init();
+          play();
+        } else {
+          pause();
+        }
+      });
+    }, { threshold: 0.5 });
+    observer.observe(packageContainer);
+    packageContainer.addEventListener('click', () => {
+      lid.rotation.x = 0;
+      logoMesh.visible = false;
+      packageContainer.classList.remove('show-logo');
+      progress = 0;
+      play();
+    });
+  };
 
   // Subscribe form handling with honeypot and reCAPTCHA
   const subscribeForm = document.querySelector('.subscribe-form');

--- a/scripts/hero-loader.js
+++ b/scripts/hero-loader.js
@@ -1,0 +1,42 @@
+(() => {
+  const hero = document.getElementById('home');
+  const packageContainer = document.getElementById('package-anim');
+  const webglSupported = !!window.WebGLRenderingContext;
+  if (!hero || !webglSupported) {
+    packageContainer?.classList.add('show-logo');
+    return;
+  }
+
+  const loadScript = (src) => new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.defer = true;
+    s.onload = () => resolve();
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+
+  const init = async () => {
+    try {
+      await Promise.all([
+        loadScript('vendor/three.min.js'),
+        loadScript('vendor/vanta.net.min.js')
+      ]);
+    } finally {
+      window.initVanta?.();
+      window.initPackageAnimation?.();
+    }
+  };
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        observer.disconnect();
+        init();
+      }
+    });
+  });
+
+  observer.observe(hero);
+})();
+


### PR DESCRIPTION
## Summary
- Remove direct Vanta/Three vendor script tags from index
- Expose init functions in `main.js` for hero and package animations
- Add loader that waits for hero visibility then imports vendor scripts and kicks off animations

## Testing
- `npm test` *(fails: required system dependencies installation terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68abdcc7ea80832c910faecfe6fe33fd