### PR TITLE
Use responsive images for featured items

### DIFF
--- a/items.json
+++ b/items.json
@@ -1,19 +1,22 @@
 {
   "ebay": [
     {
-      "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
+      "imageSmall": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=375",
+      "imageLarge": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://www.ebay.com/itm/376470178564",
       "alt": "Featured eBay collectible",
       "badge": "Only 1 left"
     },
     {
-      "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
+      "imageSmall": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=375",
+      "imageLarge": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://ebay.us/m/vs5p1e",
       "alt": "Featured eBay collectible 2",
       "stock": 1
     },
     {
-      "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
+      "imageSmall": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=350",
+      "imageLarge": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
       "link": "https://ebay.us/m/VTMaDx",
       "alt": "Featured eBay collectible 3",
       "badge": "Only 1 left"
@@ -21,19 +24,22 @@
   ],
   "offerup": [
     {
-      "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
+      "imageSmall": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=375",
+      "imageLarge": "https://www.marchingdogs.com/cdn/shop/files/IMG-9709.jpg?v=1753801631&width=750",
       "link": "https://offerup.co/44T5cRnMIVb",
       "alt": "Featured OfferUp item",
       "stock": 1
     },
     {
-      "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
+      "imageSmall": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=375",
+      "imageLarge": "https://www.marchingdogs.com/cdn/shop/files/IMG-9710.jpg?v=1753801627&width=750",
       "link": "https://offerup.co/UR4k8b1RIVb",
       "alt": "Featured OfferUp item 2",
       "badge": "Only 1 left"
     },
     {
-      "image": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
+      "imageSmall": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=350",
+      "imageLarge": "https://www.marchingdogs.com/cdn/shop/files/IMG-4266.png?v=1751830730&width=700",
       "link": "https://offerup.co/iAT3Vh4RIVb",
       "alt": "Featured OfferUp item 3",
       "stock": 1

--- a/main.js
+++ b/main.js
@@ -360,20 +360,26 @@
               }
             });
             const img = document.createElement('img');
-            img.src = item.image;
+            const small = item.imageSmall || item.imageLarge || '';
+            const large = item.imageLarge || item.imageSmall || '';
+            img.src = small;
             img.alt = item.alt;
             img.loading = 'lazy';
             try {
-              const url = new URL(item.image);
-              const widthParam = url.searchParams.get('width');
-              if (widthParam) {
-                const width = parseInt(widthParam, 10);
-                const half = Math.round(width / 2);
-                const small = new URL(item.image);
-                small.searchParams.set('width', String(half));
-                img.width = width;
-                img.height = Math.round(width * 9 / 16);
-                img.srcset = `${small.toString()} ${half}w, ${item.image} ${width}w`;
+              const getWidth = (u) => {
+                try {
+                  return parseInt(new URL(u).searchParams.get('width') || '0', 10);
+                } catch {
+                  return 0;
+                }
+              };
+              const smallW = getWidth(small);
+              const largeW = getWidth(large);
+              if (smallW && largeW) {
+                img.width = largeW;
+                img.height = Math.round(largeW * 9 / 16);
+                img.srcset = `${small} ${smallW}w, ${large} ${largeW}w`;
+                img.sizes = `(max-width: ${largeW}px) 100vw, ${largeW}px`;
               }
             } catch {}
             link.appendChild(img);
@@ -755,9 +761,28 @@
       link.rel = 'noopener noreferrer';
       link.setAttribute('aria-label', item.alt || 'Featured item');
       const img = document.createElement('img');
-      img.src = item.image;
+      const small = item.imageSmall || item.imageLarge || '';
+      const large = item.imageLarge || item.imageSmall || '';
+      img.src = small;
       img.alt = item.alt || '';
       img.loading = 'lazy';
+      try {
+        const getWidth = (u) => {
+          try {
+            return parseInt(new URL(u).searchParams.get('width') || '0', 10);
+          } catch {
+            return 0;
+          }
+        };
+        const smallW = getWidth(small);
+        const largeW = getWidth(large);
+        if (smallW && largeW) {
+          img.width = largeW;
+          img.height = Math.round(largeW * 9 / 16);
+          img.srcset = `${small} ${smallW}w, ${large} ${largeW}w`;
+          img.sizes = `(max-width: ${largeW}px) 100vw, ${largeW}px`;
+        }
+      } catch {}
       link.appendChild(img);
       display.appendChild(link);
       if (window.gtag) {

--- a/tests/featured-items.spec.ts
+++ b/tests/featured-items.spec.ts
@@ -19,8 +19,23 @@ test('featured items are in viewport and clickable', async ({ page }) => {
         link.target = '_blank';
         link.rel = 'noopener noreferrer';
         const img = document.createElement('img');
-        img.src = item.image;
+        const small = item.imageSmall || item.imageLarge;
+        const large = item.imageLarge || item.imageSmall;
+        const getWidth = (u: string) => {
+          try {
+            return parseInt(new URL(u).searchParams.get('width') || '0', 10);
+          } catch {
+            return 0;
+          }
+        };
+        const smallW = getWidth(small);
+        const largeW = getWidth(large);
+        img.src = small;
         img.alt = item.alt;
+        if (smallW && largeW) {
+          img.srcset = `${small} ${smallW}w, ${large} ${largeW}w`;
+          img.sizes = `(max-width: ${largeW}px) 100vw, ${largeW}px`;
+        }
         container.appendChild(link);
         link.appendChild(img);
       });


### PR DESCRIPTION
## Summary
- Support multiple image sizes in `items.json` and load responsive images for featured and weekly items with `srcset`/`sizes`.
- Adjust Playwright tests to accommodate new image fields.

## Testing
- `npm test` *(fails: 5 failed, 98 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68abdede8904832cb8a0c1e357b8ee0b