### PR TITLE
Add env token replacement and validation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Provide these at deploy time by setting the attributes in HTML or defining globa
 
 If left unset (or left as placeholder tokens like `%GA_ID%`), analytics is disabled, reCAPTCHA is hidden, and the phone link will be hidden.
 
+Run `npm run build` before deploying to replace the `%GA_ID%`, `%RECAPTCHA_SITE_KEY%`, and `%PHONE_NUMBER%` tokens in `env.js` with the
+values from the `GA_ID`, `RECAPTCHA_SITE_KEY`, and `PHONE_NUMBER` environment variables. The build step validates that no
+placeholder tokens remain and fails otherwise.
+
 ## Animated Background Prototype
 
 Evaluated libraries for a lightweight animated hero background:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "pretest": "node scripts/decode-font.js && node scripts/decode-logo.js && node scripts/decode-snapshots.js && playwright install --with-deps",
     "test": "playwright test",
     "fetch-items": "node scripts/fetch-items.js",
-    "update-sold": "node scripts/update-sold.js"
+    "update-sold": "node scripts/update-sold.js",
+    "apply-env": "node scripts/apply-env.js",
+    "validate-env": "node scripts/validate-env.js",
+    "build": "npm run apply-env && npm run validate-env"
   },
   "keywords": [],
   "author": "",

--- a/scripts/apply-env.js
+++ b/scripts/apply-env.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+const envPath = 'env.js';
+
+const replacements = {
+  '%GA_ID%': process.env.GA_ID || '',
+  '%RECAPTCHA_SITE_KEY%': process.env.RECAPTCHA_SITE_KEY || '',
+  '%PHONE_NUMBER%': process.env.PHONE_NUMBER || '',
+};
+
+let content = fs.readFileSync(envPath, 'utf8');
+for (const [token, value] of Object.entries(replacements)) {
+  content = content.replace(new RegExp(token, 'g'), value);
+}
+
+fs.writeFileSync(envPath, content);

--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+const content = fs.readFileSync('env.js', 'utf8');
+const tokens = ['%GA_ID%', '%RECAPTCHA_SITE_KEY%', '%PHONE_NUMBER%'];
+const missing = tokens.filter(t => content.includes(t));
+
+if (missing.length) {
+  console.error('Placeholder tokens not replaced:', missing.join(', '));
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- Add Node scripts to replace GA, reCAPTCHA, and phone placeholders with env values
- Add build script that validates no placeholder tokens remain
- Document build step for deployment

## Testing
- `GA_ID=G-TEST RECAPTCHA_SITE_KEY=TESTKEY PHONE_NUMBER=5551234 npm run build`
- `npm test` *(fails: analytics, preloader-ripple, menu, sections)*
- `npx playwright test tests/analytics.spec.ts tests/config-values.spec.ts` *(fails: analytics/config-values interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68abe47e45d4832cb49599859589081d