### PR TITLE
Allow sections to expand beyond viewport height

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,10 +9,10 @@
 /* ---------- Reset & Base ---------- */
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 html{scroll-behavior:smooth;scroll-snap-type:y mandatory}@media (max-width:640px){html{scroll-snap-type:y proximity}}
-body{font-family:'Poppins',sans-serif;background:linear-gradient(135deg,var(--black),var(--color-primary),var(--black));background-size:100% 100%;background-repeat:no-repeat;animation:bg-shift 20s ease infinite;color:var(--white)}
+body{font-family:'Poppins',sans-serif;background:linear-gradient(135deg,var(--black),var(--color-primary),var(--black));background-size:100% 100%;background-repeat:no-repeat;animation:bg-shift 20s ease infinite;color:var(--white);overflow-x:hidden}
 @keyframes bg-shift{0%,100%{background-position:0% 50%}50%{background-position:100% 50%}}
 /* ---------- Sections ---------- */
-section{position:relative;height:100dvh;min-height:100dvh;scroll-snap-align:start;display:flex;align-items:center;justify-content:center;text-align:center;background-position:center 20%;background-size:cover;background-repeat:no-repeat;background-attachment:scroll}
+section{position:relative;min-height:100dvh;scroll-snap-align:start;display:flex;align-items:center;justify-content:center;text-align:center;background-position:center 20%;background-size:cover;background-repeat:no-repeat;background-attachment:scroll}
 section::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.55);z-index:0}
 .section-content{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2.5rem calc(env(safe-area-inset-right) + 2.5rem) 2.5rem calc(env(safe-area-inset-left) + 2.5rem)}@media(prefers-reduced-motion:no-preference){.story-bg-animate,.approach-bg-animate{background-size:200% 200%;animation:bg-shift 15s ease infinite}.approach-bg-animate{animation-direction:reverse}}
 /* ---------- Card ---------- */
@@ -138,7 +138,7 @@ summary:focus{outline:2px solid var(--color-accent);outline-offset:.2rem}
     .7rem
     calc(env(safe-area-inset-left)+1.5rem);
     display:flex;justify-content:space-between;align-items:center;background:rgba(0,0,0,.45);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);z-index:10000;box-shadow:0 4px 12px rgba(0,0,0,.3)}
-.brand{font-size:1.3rem;font-weight:700;text-decoration:none;color:inherit}
+.brand{font-size:1.3rem;font-weight:700;text-decoration:none;color:inherit;margin-left:.5rem}
 .nav-toggle{width:32px;height:24px;display:flex;flex-direction:column;justify-content:space-between;background:none;border:none;cursor:pointer;z-index:10001}
 .line{width:100%;height:3px;background:var(--white);border-radius:2px;transition:transform .3s,opacity .3s}
 #theme-toggle{background:none;border:none;color:var(--white);cursor:pointer;font-size:1.2rem;margin-left:1rem}
@@ -242,7 +242,7 @@ transition: none !important;
     transform-style: preserve-3d;
     animation-delay: calc(var(--i) * 4s);
   }
-@supports not (height:100dvh){section{height:100vh;min-height:100vh}}
+@supports not (height:100dvh){section{min-height:100vh}}
 
 .site-footer{padding:
     1rem


### PR DESCRIPTION
## Summary
- remove fixed viewport height from sections and keep min-height for flexible layouts
- simplify 100vh fallback for browsers without `dvh` support
- hide horizontal overflow and pad logo from left edge

## Testing
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `npm test` *(fails: apt package install errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abe91bdf98832c81c2f0555d10ad31