### PR TITLE
Harden content security policies

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>FAQ - HecCollects</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Privacy Policy - HecCollects</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/returns.html
+++ b/returns.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Shipping & Returns - HecCollects</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/sold.html
+++ b/sold.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Sold Listings - HecCollects</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/tests/sold-visual.spec.ts
+++ b/tests/sold-visual.spec.ts
@@ -38,7 +38,7 @@ test('sold page layout should match snapshot', async ({ page }) => {
 
   await page.goto('file://' + filePath);
   await page.evaluate(() => (document as any).fonts.ready);
-  await page.addStyleTag({ content: '* { transition: none !important; animation: none !important; }' });
+    await page.emulateMedia({ reducedMotion: 'reduce' });
   const main = page.locator('main');
   await main.waitFor();
   expect(await main.screenshot()).toMatchSnapshot('sold-layout.png', { maxDiffPixelRatio: 0.01 });


### PR DESCRIPTION
## Summary
- add strict content-security-policy headers to FAQ, returns, and privacy pages
- tighten sold listing policy by dropping `unsafe-inline`
- update visual test to disable animations via reduced motion media query

## Testing
- `npm test` *(fails: GA script not detected and other related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cb30d7c832c84ac7308aac6d692