### PR TITLE
Add social preview meta tags to policy pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -21,6 +21,12 @@
   <meta property="og:title" content="FAQ - HecCollects">
   <meta property="og:description" content="Find answers to common questions about orders, shipping, returns, and policies at HecCollects.">
   <meta property="og:url" content="https://heccollects.github.io/faq.html">
+  <meta property="og:image" content="logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="FAQ - HecCollects">
+  <meta name="twitter:description" content="Find answers to common questions about orders, shipping, returns, and policies at HecCollects.">
+  <meta name="twitter:url" content="https://heccollects.github.io/faq.html">
+  <meta name="twitter:image" content="logo.png">
 </head>
 <body class="faq-page">
   <a class="skip-link" href="#main">Skip to content</a>

--- a/privacy.html
+++ b/privacy.html
@@ -21,6 +21,12 @@
   <meta property="og:title" content="Privacy Policy - HecCollects">
   <meta property="og:description" content="Read how HecCollects collects, uses, and protects your information and how you can manage your data.">
   <meta property="og:url" content="https://heccollects.github.io/privacy.html">
+  <meta property="og:image" content="logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Privacy Policy - HecCollects">
+  <meta name="twitter:description" content="Read how HecCollects collects, uses, and protects your information and how you can manage your data.">
+  <meta name="twitter:url" content="https://heccollects.github.io/privacy.html">
+  <meta name="twitter:image" content="logo.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/returns.html
+++ b/returns.html
@@ -21,6 +21,12 @@
   <meta property="og:title" content="Shipping & Returns - HecCollects">
   <meta property="og:description" content="Learn about HecCollects shipping policies, return instructions, refund timelines, and customer rights.">
   <meta property="og:url" content="https://heccollects.github.io/returns.html">
+  <meta property="og:image" content="logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Shipping & Returns - HecCollects">
+  <meta name="twitter:description" content="Learn about HecCollects shipping policies, return instructions, refund timelines, and customer rights.">
+  <meta name="twitter:url" content="https://heccollects.github.io/returns.html">
+  <meta name="twitter:image" content="logo.png">
 </head>
 <body class="returns-page">
   <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary
- Add Open Graph and Twitter card image tags for FAQ, returns, and privacy pages
- Ensure social platforms use `logo.png` for previews

## Testing
- `node scripts/decode-logo.js`
- `ls -l logo.png`
- `npm test` *(fails: installing Playwright dependencies; truncated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1cca0be4832c9f62179607117925