### PR TITLE
Add UTM tracking parameters to marketplace links

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
           <h2 id="shop-on-ebay">Shop on eBay</h2>
           <p>Browse curated listings, graded cards, and exclusive bundles at competitive prices.</p>
           <div class="links">
-            <a href="https://ebay.us/m/HoUY1I" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay"><i class="fa-brands fa-ebay" aria-hidden="true"></i> Visit eBay Store</a>
+            <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay"><i class="fa-brands fa-ebay" aria-hidden="true"></i> Visit eBay Store</a>
           </div>
           <div class="featured">
             <h3>Collector Favorites</h3>
@@ -289,7 +289,7 @@
           <h2 id="local-deals-on-offerup">Local Deals on OfferUp</h2>
           <p>Prefer local pickup? Check out my OfferUp inventory for quick deals and meet‑ups in SoCal.</p>
           <div class="links">
-            <a href="https://offerup.co/xluJorjDIVb" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup"><i class="fa-solid fa-store" aria-hidden="true"></i> Visit OfferUp</a>
+            <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup"><i class="fa-solid fa-store" aria-hidden="true"></i> Visit OfferUp</a>
           </div>
           <div class="featured">
             <h3>Collector Favorites</h3>

--- a/scripts/fetch-items.js
+++ b/scripts/fetch-items.js
@@ -7,6 +7,18 @@ const OUTPUT = path.join(ROOT, 'items.json');
 const SEARCH_TERM = process.env.SEARCH_TERM || 'collectible';
 const LIMIT = parseInt(process.env.ITEM_LIMIT || '3', 10);
 
+function addUtm(url) {
+  if (!url) return url;
+  try {
+    const u = new URL(url);
+    u.searchParams.set('utm_source', 'site');
+    u.searchParams.set('utm_medium', 'referral');
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
 async function fetchEbay() {
   const appId = process.env.EBAY_APP_ID;
   if (!appId) {
@@ -23,7 +35,7 @@ async function fetchEbay() {
   const items = json?.findItemsByKeywordsResponse?.[0]?.searchResult?.[0]?.item || [];
   return items.slice(0, LIMIT).map(item => ({
     image: item.galleryURL?.[0],
-    link: item.viewItemURL?.[0],
+    link: addUtm(item.viewItemURL?.[0]),
     alt: item.title?.[0],
     badge: item.condition?.[0]?.conditionDisplayName?.[0] || '',
     stock: Number(item.sellingStatus?.[0]?.quantity || 1)
@@ -42,7 +54,7 @@ async function fetchOfferUp() {
     const items = json?.data?.items || json?.response?.sections?.[0]?.items || [];
     return items.slice(0, LIMIT).map(it => ({
       image: it?.images?.[0]?.images?.[0]?.url || it?.image?.url || it?.picture?.url,
-      link: it?.web_url || `https://offerup.com/item/detail/${it?.id}`,
+      link: addUtm(it?.web_url || `https://offerup.com/item/detail/${it?.id}`),
       alt: it?.title || '',
       badge: it?.badges?.[0]?.name || '',
       stock: 1

--- a/scripts/update-sold.js
+++ b/scripts/update-sold.js
@@ -7,6 +7,18 @@ const OUTPUT = path.join(ROOT, 'sold-items.json');
 const SEARCH_TERM = process.env.SOLD_SEARCH_TERM || 'collectible';
 const LIMIT = parseInt(process.env.SOLD_LIMIT || '10', 10);
 
+function addUtm(url) {
+  if (!url) return url;
+  try {
+    const u = new URL(url);
+    u.searchParams.set('utm_source', 'site');
+    u.searchParams.set('utm_medium', 'referral');
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
 async function fetchEbaySold() {
   const appId = process.env.EBAY_APP_ID;
   if (!appId) {
@@ -51,7 +63,7 @@ async function fetchEbaySold() {
       },
       date: item.listingInfo?.[0]?.endTime?.[0] || '',
       location: item.location?.[0] || '',
-      url: item.viewItemURL?.[0] || '',
+      url: addUtm(item.viewItemURL?.[0] || ''),
       image: item.galleryURL?.[0] || '',
       platform: 'ebay',
       condition:


### PR DESCRIPTION
## Summary
- append standard utm_source/utm_medium tracking to eBay and OfferUp URLs in fetch-items and update-sold scripts
- update static marketplace links on the landing page with matching UTM params
- ensure sold-items refresh retains UTM tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae96f4c5bc832c8795fca7ae9fb201