### PR TITLE
Add referral code support and share link tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Example cron entry sending Monday at 9 AM:
 
 In GitHub Actions, use a `schedule` trigger with the same command to automate delivery.
 
+## Referral Codes
+
+Visitors can share a `ref` code by appending `?ref=CODE` to the site URL. The code is stored in `localStorage`, included with `#subscribe` form submissions via a hidden `referrer` field, and appended to outbound links marked with `data-share-link`. This allows referrals to persist across sessions and be tracked when links are shared.
+
+Visiting the site with an empty `?ref=` parameter clears any previously stored code.
+
+Rewards can be granted when a referral leads to a newsletter signup or purchase. For example, a user might earn a discount or credit after a set number of successful referrals.
+
 ## Configuration
 
 `config.js` reads optional values from its `<script>` tag's `data-` attributes or existing `window` properties.

--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
           <h2 id="shop-on-ebay">Shop on eBay</h2>
           <p>Browse curated listings, graded cards, and exclusive bundles at competitive prices.</p>
           <div class="links">
-            <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay"><i class="fa-brands fa-ebay" aria-hidden="true"></i> Visit eBay Store</a>
+            <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay" data-share-link><i class="fa-brands fa-ebay" aria-hidden="true"></i> Visit eBay Store</a>
           </div>
           <div class="featured">
             <h3>Collector Favorites</h3>
@@ -267,7 +267,7 @@
           <h2 id="local-deals-on-offerup">Local Deals on OfferUp</h2>
           <p>Prefer local pickup? Check out my OfferUp inventory for quick deals and meet‑ups in SoCal.</p>
           <div class="links">
-            <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup"><i class="fa-solid fa-store" aria-hidden="true"></i> Visit OfferUp</a>
+            <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup" data-share-link><i class="fa-solid fa-store" aria-hidden="true"></i> Visit OfferUp</a>
           </div>
           <div class="featured">
             <h3>Collector Favorites</h3>
@@ -297,6 +297,7 @@
               <label><input type="checkbox" name="interests" value="electronics"> Electronics</label>
             </div>
             <input type="hidden" name="source" value="homepage">
+            <input type="hidden" name="referrer" id="referrer-field">
             <p class="privacy">We’ll never sell your data. <a href="privacy.html">Privacy Policy</a></p>
             <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
             <div class="g-recaptcha" data-sitekey="" data-callback="enableSubscribe"></div>
@@ -315,7 +316,7 @@
           <p>Have a question, bulk lot, or collaboration idea? Reach out and I’ll get back within 24 hours.</p>
           <div class="links">
             <a href="mailto:hectorsandoval1402@gmail.com" class="btn border-fade" data-analytics="email"><i class="fa-solid fa-envelope" aria-hidden="true"></i> Email Me</a>
-            <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="instagram"><i class="fa-brands fa-instagram" aria-hidden="true"></i> Instagram</a>
+            <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="instagram" data-share-link><i class="fa-brands fa-instagram" aria-hidden="true"></i> Instagram</a>
             <a id="phone-link" href="tel:" class="btn border-fade hidden" data-analytics="phone"><i class="fa-solid fa-phone" aria-hidden="true"></i> Call Me</a>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,52 @@
 (() => {
   const root = document.documentElement;
   const themeToggle = document.getElementById('theme-toggle');
+  let refCode = '';
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('ref')) {
+      const ref = params.get('ref') || '';
+      if (ref) {
+        localStorage.setItem('ref', ref);
+        refCode = ref;
+      } else {
+        localStorage.removeItem('ref');
+        refCode = '';
+      }
+    } else {
+      refCode = localStorage.getItem('ref') || '';
+    }
+  } catch {}
+
+  if (refCode) {
+    document.querySelectorAll('a[data-share-link]').forEach(link => {
+      try {
+        const url = new URL(link.href, location.href);
+        if (!url.searchParams.get('ref')) {
+          url.searchParams.set('ref', refCode);
+        }
+        link.href = url.toString();
+      } catch {}
+    });
+  }
+
+  const subscribeForm = document.querySelector('#subscribe form');
+  if (subscribeForm) {
+    const refField = subscribeForm.querySelector('#referrer-field');
+    try {
+      if (refField && refCode) {
+        refField.value = refCode;
+      }
+    } catch {}
+    subscribeForm.addEventListener('submit', () => {
+      if (refField && !refField.value) {
+        try {
+          refField.value = localStorage.getItem('ref') || '';
+        } catch {}
+      }
+    });
+  }
+
   let storedTheme = 'dark';
   try {
     storedTheme = localStorage.getItem('theme') || 'dark';


### PR DESCRIPTION
## Summary
- Capture `ref` query parameter on load, persist in localStorage, and append to marked outbound links and newsletter signups
- Clear stored referral code when visiting with an empty `ref` parameter and document the behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea6b4de1c832c82b4c674b381cd4b