### PR TITLE
feat: sort and dedupe sold items

### DIFF
--- a/scripts/update-sold.js
+++ b/scripts/update-sold.js
@@ -160,7 +160,18 @@ async function main() {
     fetchTcgPlayerSold()
   ]);
   const sold = [...ebay, ...tcgplayer];
-  await fs.writeFile(OUTPUT, JSON.stringify(sold, null, 2));
+
+  sold.sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  const seen = new Set();
+  const deduped = sold.filter(item => {
+    const key = `${item.title}__${item.date}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  await fs.writeFile(OUTPUT, JSON.stringify(deduped, null, 2));
   console.log(`Wrote ${OUTPUT}`);
 }
 


### PR DESCRIPTION
## Summary
- sort combined eBay and TCGplayer sold lists by date desc
- remove duplicates by title and date before saving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afa652bda0832c9200dc667369991d