### PR TITLE
Improve monthly summary formatting

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -249,20 +249,34 @@ function updateSummary(items) {
   const prices = items.map(item => parsePrice(item.price)).filter(n => !isNaN(n));
   const avg = prices.reduce((a, b) => a + b, 0) / prices.length;
   avgPriceEl.textContent = `Average price: $${avg.toFixed(2)}`;
-
   const monthlyTotals = {};
   items.forEach(item => {
     const date = item.date ? new Date(item.date) : null;
     if (!date || isNaN(date)) return;
-    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-    monthlyTotals[key] = (monthlyTotals[key] || 0) + parsePrice(item.price);
+    const monthKey = Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      1
+    );
+    monthlyTotals[monthKey] =
+      (monthlyTotals[monthKey] || 0) + parsePrice(item.price);
+  });
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC'
   });
   monthlySalesEl.innerHTML = '';
-  Object.keys(monthlyTotals).sort().forEach(key => {
-    const li = document.createElement('li');
-    li.textContent = `${key}: $${monthlyTotals[key].toFixed(2)}`;
-    monthlySalesEl.appendChild(li);
-  });
+  Object.keys(monthlyTotals)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .forEach(key => {
+      const li = document.createElement('li');
+      li.textContent = `${formatter.format(new Date(Number(key)))}: $${
+        monthlyTotals[key].toFixed(2)
+      }`;
+      monthlySalesEl.appendChild(li);
+    });
 }
 
 function updateChart(items) {

--- a/tests/sold.spec.ts
+++ b/tests/sold.spec.ts
@@ -85,6 +85,10 @@ test('renders price points when data available', async ({ page }) => {
   const card = page.locator('#condition-comparison .condition-card').first();
   await expect(card.locator('h3')).toHaveText('Near Mint');
   await expect(card.locator('p')).toHaveText('$90.00');
+  await expect(page.locator('#avg-price')).toHaveText('Average price: $90.00');
+  await expect(page.locator('#monthly-sales li').first()).toHaveText(
+    'Apr 2099: $180.00'
+  );
 });
 
 test('three month snapshot reflects recent sales', async ({ page }) => {


### PR DESCRIPTION
## Summary
- use `Intl.DateTimeFormat` to display monthly totals with short month names
- update sold page test expectations for average price and monthly summaries

## Testing
- `npx playwright test tests/sold.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68afbfa97ee8832c86edb202441af36f