### PR TITLE
Add sold platform filter test and month formatting

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -271,7 +271,7 @@ function updateSummary(items) {
       (monthlyTotals[monthKey] || 0) + parsePrice(item.price);
   });
   const formatter = new Intl.DateTimeFormat('en-US', {
-    month: 'short',
+    month: 'long',
     year: 'numeric',
     timeZone: 'UTC'
   });


### PR DESCRIPTION
## Summary
- expand sold page tests with platform filtering and link handling coverage
- expect full month names in sold summary and update script accordingly
- tighten search debounce test to observe DOM mutations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b059023100832cbd9e76c41a55fd42