### PR TITLE
ci: run tests before committing sold items

### DIFF
--- a/.github/workflows/update-sold.yml
+++ b/.github/workflows/update-sold.yml
@@ -17,7 +17,10 @@ jobs:
         env:
           EBAY_APP_ID: ${{ secrets.EBAY_APP_ID }}
         run: npm ci && npm run update-sold
+      - name: Run tests
+        run: npm test
       - name: Commit and push if sold items changed
+        if: success()
         run: |
           if [ -n "$(git status --porcelain sold-items.json)" ]; then
             git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- run `npm test` after `npm run update-sold`
- only commit `sold-items.json` if tests succeed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b066b42814832cbe66bb94159a1713