### PR TITLE
Add search suggestions to sold listings

### DIFF
--- a/scripts/sold.js
+++ b/scripts/sold.js
@@ -13,6 +13,7 @@ const snapshotEl = document.getElementById('three-month-snapshot');
 const tableEl = document.getElementById('sold-table');
 const skeletonChart = document.querySelector('.skeleton-chart');
 const skeletonTable = document.querySelector('.skeleton-table');
+const suggestionsEl = document.getElementById('sold-suggestions');
 chartCanvas.height = 300;
 const chartCtx = chartCanvas.getContext('2d');
 let rangeButtons;
@@ -91,6 +92,16 @@ function populatePlatformFilter(items) {
   if (platforms.includes(prev)) {
     platformFilterEl.value = prev;
   }
+}
+
+function populateSearchSuggestions(items) {
+  const titles = Array.from(new Set(items.map(i => i.title).filter(Boolean)));
+  suggestionsEl.innerHTML = '';
+  titles.forEach(title => {
+    const option = document.createElement('option');
+    option.value = title;
+    suggestionsEl.appendChild(option);
+  });
 }
 
 function filterItems(items) {
@@ -512,6 +523,7 @@ async function loadSoldItems() {
       platform: item.platform || '',
       condition: item.condition || ''
     }));
+    populateSearchSuggestions(allItems);
     statusEl.textContent = '';
     skeletonChart?.classList.add('hidden');
     skeletonTable?.classList.add('hidden');

--- a/sold.html
+++ b/sold.html
@@ -43,7 +43,8 @@
         <option value="">All Platforms</option>
       </select>
       <label for="sold-search">Search:</label>
-      <input type="search" id="sold-search" placeholder="Search listings">
+      <input type="search" id="sold-search" placeholder="Search listings" list="sold-suggestions">
+      <datalist id="sold-suggestions"></datalist>
     </div>
     <div id="summary">
       <p id="avg-price"></p>


### PR DESCRIPTION
## Summary
- add datalist to sold listings search box
- populate search suggestions with item titles
- trigger suggestions after data loads

## Testing
- `npm test` *(fails: reCAPTCHA and phone link use provided window values)*

------
https://chatgpt.com/codex/tasks/task_e_68b110b05aa4832caa4fe32d251ea13f