### PR TITLE
chore: improve search item loading

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -27,11 +27,17 @@ if (input && suggestions) {
   };
 
   const loadItems = () => {
-    const isNativeFetch = window.fetch.toString().includes('[native code]');
-    if (location.protocol === 'file:' && isNativeFetch) {
+    if (location.protocol === 'file:' && typeof fetch === 'function') {
       window.searchIndexLoaded = true;
       return Promise.resolve();
     }
+
+    if (typeof fetch !== 'function') {
+      console.warn('Search index not loaded: fetch is unavailable');
+      window.searchIndexLoaded = true;
+      return Promise.resolve();
+    }
+
     return fetch('items.json')
       .then(response => response.json())
       .then(data => {
@@ -48,7 +54,9 @@ if (input && suggestions) {
           });
         });
       })
-      .catch(() => {})
+      .catch(err => {
+        console.warn('Failed to load search index', err);
+      })
       .finally(() => {
         window.searchIndexLoaded = true;
       });


### PR DESCRIPTION
## Summary
- replace brittle `fetch.toString()` check with a simple protocol/type guard
- log missing fetch or network errors and ensure search index reports loaded state

## Testing
- `npm test` *(fails: Playwright dependency installation did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b138b4b508832c8fc01ae3781bbe2e