### PR TITLE
feat: fail when env placeholders remain

### DIFF
--- a/scripts/apply-env.js
+++ b/scripts/apply-env.js
@@ -14,3 +14,10 @@ for (const [token, value] of Object.entries(replacements)) {
 }
 
 fs.writeFileSync(envPath, content);
+
+const finalContent = fs.readFileSync(envPath, 'utf8');
+const remainingTokens = Object.keys(replacements).filter((token) => finalContent.includes(token));
+if (remainingTokens.length > 0) {
+  console.error(`The following placeholders were not replaced in ${envPath}: ${remainingTokens.join(', ')}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- ensure apply-env verifies that placeholders are fully replaced

## Testing
- `node scripts/apply-env.js && cat env.js`
- `npm test` *(fails: process interrupted due to extensive dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b1529af0f0832caea2085384ce18bc