### PR TITLE
feat: redesign site colors and default to light theme

### DIFF
--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -47,9 +47,9 @@
     });
   }
 
-  let storedTheme = 'dark';
+  let storedTheme = 'light';
   try {
-    storedTheme = localStorage.getItem('theme') || 'dark';
+    storedTheme = localStorage.getItem('theme') || 'light';
   } catch {}
   const applyTheme = (t) => {
     root.setAttribute('data-theme', t);

--- a/style.css
+++ b/style.css
@@ -1,9 +1,10 @@
+/* Global color variables use a light palette by default */
 :root {
-  --black: #151515;
-  --white: #ffffff;
-  --color-primary: #1e3c72;
-  --color-secondary: #2a5298;
-  --color-accent: #f28c2f;
+  --black: #26536b;
+  --white: #f6f0ed;
+  --color-primary: #7ea8be;
+  --color-secondary: #bbb193;
+  --color-accent: #c2948a;
   --navbar-height: calc(env(safe-area-inset-top) + 5rem);
 }
 /* ---------- Reset & Base ---------- */
@@ -27,14 +28,14 @@ body {
   font-family: "Poppins", sans-serif;
   background: linear-gradient(
     135deg,
-    var(--black),
+    var(--white),
     var(--color-primary),
-    var(--black)
+    var(--white)
   );
   background-size: 100% 100%;
   background-repeat: no-repeat;
   animation: bg-shift 20s ease infinite;
-  color: var(--white);
+  color: var(--black);
   overflow-x: hidden;
 }
 @keyframes bg-shift {
@@ -679,7 +680,7 @@ summary:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(255, 255, 255, 0.6);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   z-index: 10000;
@@ -706,7 +707,7 @@ summary:focus {
 .line {
   width: 100%;
   height: 3px;
-  background: var(--white);
+  background: var(--black);
   border-radius: 2px;
   transition:
     transform 0.3s,
@@ -715,7 +716,7 @@ summary:focus {
 #theme-toggle {
   background: none;
   border: none;
-  color: var(--white);
+  color: var(--black);
   cursor: pointer;
   font-size: 1.2rem;
   margin-left: 1rem;
@@ -744,7 +745,7 @@ summary:focus {
   gap: 2.4rem;
   overflow-y: auto;
   padding: 2rem;
-  background: rgba(21, 21, 21, 0.85);
+  background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.55);
@@ -762,7 +763,7 @@ summary:focus {
   opacity: 1;
 }
 .nav-menu a {
-  color: var(--white);
+  color: var(--black);
   font-size: 1.8rem;
   font-weight: 600;
   text-decoration: none;

--- a/theme.css
+++ b/theme.css
@@ -1,21 +1,21 @@
 :root {
-  --bg-start: var(--color-primary);
+  --bg-start: var(--white);
   --bg-end: var(--color-secondary);
 }
 
-:root[data-theme="light"] {
-  --black: #ffffff;
-  --white: #151515;
-  --color-primary: #f5f5f5;
-  --color-secondary: #e0e0e0;
-  --color-accent: #1e3c72;
-  --bg-start: #ffffff;
-  --bg-end: #e0e0e0;
+:root[data-theme="dark"] {
+  --black: #f6f0ed;
+  --white: #26536b;
+  --color-primary: #26536b;
+  --color-secondary: #7ea8be;
+  --color-accent: #c2948a;
+  --bg-start: #26536b;
+  --bg-end: #7ea8be;
 }
 
 body {
   background: linear-gradient(to bottom, var(--bg-start), var(--bg-end));
-  color: var(--white);
+  color: var(--black);
   opacity: 0;
   position: relative;
   z-index: 0;
@@ -53,28 +53,36 @@ body.fade-out {
 
 /* Page-specific theme overrides */
 body.privacy-page {
-  --bg-start: #0b3d91;
-  --bg-end: #1e90ff;
+  --bg-start: #7ea8be;
+  --bg-end: #26536b;
 }
 
 body.returns-page {
-  --bg-start: #5e2e2e;
-  --bg-end: #b34747;
+  --bg-start: #c2948a;
+  --bg-end: #bbb193;
 }
 
 body.faq-page {
-  --bg-start: #005f73;
-  --bg-end: #0a9396;
+  --bg-start: #bbb193;
+  --bg-end: #7ea8be;
 }
 
-[data-theme="light"] .navbar {
-  background: rgba(255, 255, 255, 0.6);
+[data-theme="dark"] .navbar {
+  background: rgba(0, 0, 0, 0.45);
 }
 
-[data-theme="light"] .nav-menu {
-  background: rgba(255, 255, 255, 0.85);
+[data-theme="dark"] .nav-menu {
+  background: rgba(21, 21, 21, 0.85);
 }
 
-[data-theme="light"] .nav-menu a {
+[data-theme="dark"] .nav-menu a {
+  color: var(--white);
+}
+
+[data-theme="dark"] .line {
+  background: var(--white);
+}
+
+[data-theme="dark"] #theme-toggle {
   color: var(--white);
 }


### PR DESCRIPTION
## Summary
- apply new palette variables across site
- set light theme as default and add dark-mode overrides
- update theme script to remember light/dark preference

## Testing
- `npm test` *(fails: E: Write error - write (14: Bad address))*

------
https://chatgpt.com/codex/tasks/task_e_68b3cd688b14832ca4699e66fe91886a