### PR TITLE
Fix light background gradient in theme

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -16,7 +16,12 @@
 }
 
 body {
-  background: linear-gradient(to bottom, var(--bg-start), var(--bg-end));
+  background: linear-gradient(
+    to bottom,
+    var(--bg-start),
+    #e5e5e5,
+    var(--bg-end)
+  );
   color: var(--black);
   opacity: 0;
   position: relative;
@@ -39,7 +44,12 @@ body::before {
   content: "";
   position: fixed;
   inset: 0;
-  background: linear-gradient(to bottom, var(--bg-start), var(--bg-end));
+  background: linear-gradient(
+    to bottom,
+    var(--bg-start),
+    #e5e5e5,
+    var(--bg-end)
+  );
   z-index: -1;
   pointer-events: none;
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- keep light theme gradient's grey midpoint
- remove leftover alternative color references

## Testing
- `npm test` *(fails: playwright dependency installation did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b4675406dc832c8bd4a73fb33cae2d