### PR TITLE
feat: implement color palette and theme toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,12 +1,5 @@
-/* Global color variables use a light palette by default */
-:root {
-  --black: #26536b;
-  --white: #f6f0ed;
-  --color-primary: #7ea8be;
-  --color-secondary: #bbb193;
-  --color-accent: #c2948a;
-  --navbar-height: calc(env(safe-area-inset-top) + 5rem);
-}
+/* Global styles */
+/* Color variables are defined in theme.css */
 /* ---------- Reset & Base ---------- */
 *,
 *::before,
@@ -28,14 +21,14 @@ body {
   font-family: "Poppins", sans-serif;
   background: linear-gradient(
     135deg,
-    var(--white),
-    var(--color-primary),
-    var(--white)
+    var(--color-bg),
+    var(--brand-primary),
+    var(--color-bg)
   );
   background-size: 100% 100%;
   background-repeat: no-repeat;
   animation: bg-shift 20s ease infinite;
-  color: var(--black);
+  color: var(--color-text);
   overflow-x: hidden;
 }
 @keyframes bg-shift {

--- a/theme.css
+++ b/theme.css
@@ -1,25 +1,46 @@
 :root {
-  --black: #111111;
-  --white: #ffffff;
-  --bg-start: var(--white);
-  --bg-end: #e5e5e5;
+  /* 60% grayscale foundation */
+  --color-bg: #f6f0ed;
+  --color-surface: #ffffff;
+  --color-text: #111111;
+  --color-muted: #bbb193;
+
+  /* 30% brand colors */
+  --brand-primary: #26536b;
+  --brand-secondary: #7ea8be;
+
+  /* 10% accent color */
+  --accent: #c2948a;
+
+  --navbar-height: calc(env(safe-area-inset-top) + 5rem);
+
+  /* legacy aliases */
+  --black: var(--color-text);
+  --white: var(--color-bg);
+  --color-primary: var(--brand-primary);
+  --color-secondary: var(--brand-secondary);
+  --color-accent: var(--accent);
 }
 
 :root[data-theme="dark"] {
-  --black: #ffffff;
-  --white: #111111;
-  --bg-start: var(--white);
-  --bg-end: #e5e5e5;
+  --color-bg: #111111;
+  --color-surface: #1a1a1a;
+  --color-text: #f6f0ed;
+  --color-muted: #444444;
+
+  --brand-primary: #7ea8be;
+  --brand-secondary: #26536b;
+  --accent: #e4b6ad;
 }
 
 body {
   background: linear-gradient(
     to bottom,
-    var(--bg-start),
-    #e5e5e5,
-    var(--bg-end)
+    var(--color-bg),
+    var(--color-surface),
+    var(--color-bg)
   );
-  color: var(--black);
+  color: var(--color-text);
   opacity: 0;
   position: relative;
   z-index: 0;
@@ -43,9 +64,9 @@ body::before {
   inset: 0;
   background: linear-gradient(
     to bottom,
-    var(--bg-start),
-    #e5e5e5,
-    var(--bg-end)
+    var(--color-bg),
+    var(--color-surface),
+    var(--color-bg)
   );
   z-index: -1;
   pointer-events: none;
@@ -60,22 +81,6 @@ body.fade-out {
   opacity: 0;
 }
 
-/* Page-specific theme overrides */
-body.privacy-page {
-  --bg-start: #7ea8be;
-  --bg-end: #26536b;
-}
-
-body.returns-page {
-  --bg-start: #c2948a;
-  --bg-end: #bbb193;
-}
-
-body.faq-page {
-  --bg-start: #bbb193;
-  --bg-end: #7ea8be;
-}
-
 [data-theme="dark"] .navbar {
   background: rgba(0, 0, 0, 0.45);
 }
@@ -85,13 +90,14 @@ body.faq-page {
 }
 
 [data-theme="dark"] .nav-menu a {
-  color: var(--white);
+  color: var(--color-text);
 }
 
 [data-theme="dark"] .line {
-  background: var(--white);
+  background: var(--color-text);
 }
 
 [data-theme="dark"] #theme-toggle {
-  color: var(--white);
+  color: var(--color-text);
 }
+


### PR DESCRIPTION
## Summary
- centralize light and dark theme color tokens
- update global styles to use new palette variables

## Testing
- `npm test` *(fails: 1 failed, 2 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b472ac0d8c832c864e6babdc548add