### PR TITLE
Enable search index fetch when available

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -27,11 +27,6 @@ if (input && suggestions) {
   };
 
   const loadItems = () => {
-    if (location.protocol === 'file:' && typeof fetch === 'function') {
-      window.searchIndexLoaded = true;
-      return Promise.resolve();
-    }
-
     if (typeof fetch !== 'function') {
       console.warn('Search index not loaded: fetch is unavailable');
       window.searchIndexLoaded = true;


### PR DESCRIPTION
## Summary
- Always attempt to fetch `items.json` in the search helper when `fetch` exists
- Keep warning when `fetch` is missing

## Testing
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `npm test` *(fails: 14 failed, 2 interrupted, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b481c551e4832ca732d952a6937061