### PR TITLE
refactor: avoid fixed delays in search tests

### DIFF
--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -25,7 +25,7 @@ test('shows suggestions for matching input', async ({ page }) => {
   });
 
   await page.goto('file://' + filePath);
-  await page.waitForTimeout(500);
+  await page.waitForFunction(() => (window as any).searchIndexLoaded);
   await page.fill('#product-search', 'mag');
   const options = page.locator('#search-suggestions li');
   await expect(options).toHaveCount(1);
@@ -62,12 +62,12 @@ test('allows keyboard navigation of suggestions', async ({ page }) => {
   });
 
   await page.goto('file://' + filePath);
-  await page.waitForTimeout(500);
+  await page.waitForFunction(() => (window as any).searchIndexLoaded);
   await page.fill('#product-search', 'mag');
   await page.keyboard.press('ArrowDown');
   const active = page.locator('#search-suggestions li.active');
   await expect(active).toHaveText('Magic Card');
   await page.keyboard.press('Enter');
-  await page.waitForTimeout(100);
+  await expect.poll(() => assigned).toBeDefined();
   expect(assigned).toBe('https://example.com/magic');
 });


### PR DESCRIPTION
## Summary
- wait for search index load instead of fixed timeout
- poll for navigation event instead of sleeping

## Testing
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b485fe4e90832c9f7904681977abba