### PR TITLE
chore: await mutation observer in sold test

### DIFF
--- a/tests/sold.spec.ts
+++ b/tests/sold.spec.ts
@@ -274,7 +274,7 @@ test('debounces render on rapid search input', async ({ page }) => {
   });
 
   await page.type('#sold-search', 'abc', { delay: 50 });
-  await page.waitForTimeout(400);
+  await page.waitForFunction(() => (window as any).__renderCallCount === 1);
   const count = await page.evaluate(() => (window as any).__renderCallCount);
   expect(count).toBe(1);
 });


### PR DESCRIPTION
## Summary
- wait for sold search MutationObserver instead of fixed timeout

## Testing
- `npx playwright test tests/sold.spec.ts` *(fails: debounces render on rapid search input, others)*


------
https://chatgpt.com/codex/tasks/task_e_68b48785991c832cba724bb087e6954f