### PR TITLE
Refine layout spacing and alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
     <!-- HOME -->
     <section id="home">
       <div class="section-content">
-        <div class="card tilt reveal">
+        <div class="card card-center tilt reveal">
           <div id="package-anim" class="package-anim">
             <img src="logo.png" alt="HecCollects logo representing the collector community" class="logo" width="160" height="160" fetchpriority="high">
           </div>

--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@
   --font-size-h3: 1.25rem;
   --line-height-base: 1.6;
   --line-height-heading: 1.3;
+  --content-gap: 1.5rem;
 }
 /* ---------- Reset & Base ---------- */
 *,
@@ -72,6 +73,14 @@ section::after {
   background: rgba(0, 0, 0, 0.55);
   z-index: 0;
 }
+
+section + section {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+section:nth-of-type(even)::after {
+  background: rgba(0, 0, 0, 0.45);
+}
 .section-content {
   position: relative;
   z-index: 1;
@@ -80,6 +89,7 @@ section::after {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: var(--content-gap);
   padding: 2.5rem calc(env(safe-area-inset-right) + 2.5rem) 2.5rem
     calc(env(safe-area-inset-left) + 2.5rem);
 }
@@ -100,15 +110,24 @@ section::after {
   -webkit-backdrop-filter: blur(8px);
   border: 2px solid rgba(255, 255, 255, 0.18);
   border-radius: 1.6rem;
-  padding: 2rem 2rem;
+  padding: 2rem;
   width: 100%;
   max-width: 460px;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
   transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  gap: var(--content-gap);
+  text-align: left;
+}
+.card p {
+  margin-bottom: 0;
+}
+
+.card-center {
   align-items: center;
-  gap: 1.4rem;
+  text-align: center;
 }
 .card:hover {
   transform: translateY(-10px) rotateX(5deg) rotateY(-5deg);
@@ -168,7 +187,7 @@ section::after {
 h1,
 h2,
 h3 {
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--content-gap);
   line-height: var(--line-height-heading);
 }
 h1 {
@@ -198,7 +217,7 @@ p {
   font-size: var(--font-size-base);
   line-height: var(--line-height-base);
   max-width: 680px;
-  margin-bottom: 1rem;
+  margin-bottom: var(--content-gap);
 }
 noscript p {
   margin: 1rem;


### PR DESCRIPTION
## Summary
- introduce `--content-gap` spacing variable and apply to cards, sections and headings
- add separators and alternating overlays between sections for clearer visual breaks
- left-align card content and center hero card with new `.card-center` helper

## Testing
- `node scripts/decode-font.js`
- `node scripts/decode-logo.js`
- `npm test` *(failed: 2 failed, 2 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b505e2df6c832c93410f40aae4abaa