### PR TITLE
Differentiate primary and secondary CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,11 @@
           <div id="package-anim" class="package-anim">
             <img src="logo.png" alt="HecCollects logo representing the collector community" class="logo" width="160" height="160" fetchpriority="high">
           </div>
-          <h1 id="mission">Connecting collectors to trusted finds—and each other</h1>
+            <h1 id="mission">Connecting collectors to trusted finds—and each other</h1>
+            <div class="links">
+              <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn primary-cta cta-glow" data-analytics="ebay" data-share-link>Shop eBay</a>
+              <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn secondary-cta" data-analytics="offerup" data-share-link>Browse OfferUp</a>
+            </div>
         </div>
         <div class="feature-marquee-container">
           <ul class="feature-marquee">
@@ -184,8 +188,8 @@
         <div class="card reveal" id="weekly-feature">
           <h2 id="featured-item-of-the-week">Featured Item of the Week</h2>
           <p>Discover a random collectible each visit.</p>
-          <div id="weekly-item" aria-live="polite">Featured item will appear here.</div>
-          <button id="weekly-refresh" class="btn border-fade" aria-label="Show featured item of the week">Show Featured Item</button>
+            <div id="weekly-item" aria-live="polite">Featured item will appear here.</div>
+            <button id="weekly-refresh" class="btn secondary-cta" aria-label="Show featured item of the week">Show Item</button>
         </div>
       </div>
     </section>
@@ -244,7 +248,7 @@
           <h2 id="shop-on-ebay">Shop on eBay</h2>
           <p>Browse curated listings, graded cards, and exclusive bundles at competitive prices.</p>
           <div class="links">
-            <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="ebay" data-share-link><i class="fa-brands fa-ebay" aria-hidden="true"></i> Visit eBay Store</a>
+            <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn primary-cta cta-glow" data-analytics="ebay" data-share-link><i class="fa-brands fa-ebay" aria-hidden="true"></i> Shop eBay</a>
           </div>
           <div class="featured">
             <h3>Collector Favorites</h3>
@@ -267,7 +271,7 @@
           <h2 id="local-deals-on-offerup">Local Deals on OfferUp</h2>
           <p>Prefer local pickup? Check out my OfferUp inventory for quick deals and meet‑ups in SoCal.</p>
           <div class="links">
-            <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="offerup" data-share-link><i class="fa-solid fa-store" aria-hidden="true"></i> Visit OfferUp</a>
+            <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn secondary-cta" data-analytics="offerup" data-share-link><i class="fa-solid fa-store" aria-hidden="true"></i> Browse OfferUp</a>
           </div>
           <div class="featured">
             <h3>Collector Favorites</h3>
@@ -301,7 +305,7 @@
             <p class="privacy">We’ll never sell your data. <a href="privacy.html">Privacy Policy</a></p>
             <input type="text" name="hp" class="honeypot" autocomplete="off" tabindex="-1">
             <div class="g-recaptcha" data-sitekey="" data-callback="enableSubscribe"></div>
-            <button type="submit" class="btn border-fade" disabled>Subscribe</button>
+            <button type="submit" class="btn primary-cta" disabled>Subscribe</button>
             <p id="subscribe-msg" class="form-msg" aria-live="polite"></p>
           </form>
         </div>
@@ -315,9 +319,9 @@
           <h2 id="business-inquiries">Business Inquiries</h2>
           <p>Have a question, bulk lot, or collaboration idea? Reach out and I’ll get back within 24 hours.</p>
           <div class="links">
-            <a href="mailto:hectorsandoval1402@gmail.com" class="btn border-fade" data-analytics="email"><i class="fa-solid fa-envelope" aria-hidden="true"></i> Email Me</a>
-            <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn border-fade" data-analytics="instagram" data-share-link><i class="fa-brands fa-instagram" aria-hidden="true"></i> Instagram</a>
-            <a id="phone-link" href="tel:" class="btn border-fade hidden" data-analytics="phone"><i class="fa-solid fa-phone" aria-hidden="true"></i> Call Me</a>
+            <a href="mailto:hectorsandoval1402@gmail.com" class="btn primary-cta" data-analytics="email"><i class="fa-solid fa-envelope" aria-hidden="true"></i> Email Me</a>
+            <a href="https://instagram.com/heccollects" target="_blank" rel="noopener noreferrer" class="btn secondary-cta" data-analytics="instagram" data-share-link><i class="fa-brands fa-instagram" aria-hidden="true"></i> Visit Instagram</a>
+            <a id="phone-link" href="tel:" class="btn secondary-cta hidden" data-analytics="phone"><i class="fa-solid fa-phone" aria-hidden="true"></i> Call Now</a>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -317,6 +317,22 @@ summary:focus {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.primary-cta {
+  padding: 1.1rem 1.5rem;
+  font-size: 1.2rem;
+}
+
+.secondary-cta {
+  background: transparent;
+  color: var(--color-accent);
+  border: 2px solid var(--color-accent);
+}
+
+.secondary-cta:hover {
+  background: var(--color-accent);
+  color: var(--color-text);
+}
 .border-fade {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- Add hero call-to-action buttons for eBay and OfferUp near the top of the page
- Introduce `.primary-cta` and `.secondary-cta` button styles for visual hierarchy
- Update button labels and classes across sections to be concise and action-oriented

## Testing
- `npm test` *(fails: sold page layout snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b508f7d024832ca5454da961c7b478