### PR TITLE
Add engagement analytics

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,7 +1,7 @@
 <footer class="site-footer">
-  <a href="#home">Home</a>
-  <a href="sold.html">Sold Listings</a>
-  <a href="faq.html">FAQ</a>
-  <a href="returns.html">Returns</a>
-  <a href="privacy.html">Privacy Policy</a>
+  <a href="#home" data-analytics="footer-home">Home</a>
+  <a href="sold.html" data-analytics="footer-sold">Sold Listings</a>
+  <a href="faq.html" data-analytics="footer-faq">FAQ</a>
+  <a href="returns.html" data-analytics="footer-returns">Returns</a>
+  <a href="privacy.html" data-analytics="footer-privacy">Privacy Policy</a>
 </footer>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,19 +1,19 @@
 <header class="navbar">
-  <a href="#home" class="brand">
+  <a href="#home" class="brand" data-analytics="nav-home">
     <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
   </a>
   <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-        <a href="#testimonials">Success Stories</a>
-        <a href="#story">Our Story</a>
-        <a href="#approach">Built on Trust</a>
-    <a href="#ebay">eBay</a>
-    <a href="#offerup">OfferUp</a>
-    <a href="#subscribe">Subscribe</a>
-    <a href="#contact">Business Inquiries</a>
-    <a href="sold.html">Sold Listings</a>
-    <a href="faq.html">FAQ</a>
-    <a href="returns.html">Returns</a>
-    <a href="privacy.html">Privacy Policy</a>
+        <a href="#testimonials" data-analytics="nav-testimonials">Success Stories</a>
+        <a href="#story" data-analytics="nav-story">Our Story</a>
+        <a href="#approach" data-analytics="nav-approach">Built on Trust</a>
+    <a href="#ebay" data-analytics="nav-ebay">eBay</a>
+    <a href="#offerup" data-analytics="nav-offerup">OfferUp</a>
+    <a href="#subscribe" data-analytics="nav-subscribe">Subscribe</a>
+    <a href="#contact" data-analytics="nav-contact">Business Inquiries</a>
+    <a href="sold.html" data-analytics="nav-sold">Sold Listings</a>
+    <a href="faq.html" data-analytics="nav-faq">FAQ</a>
+    <a href="returns.html" data-analytics="nav-returns">Returns</a>
+    <a href="privacy.html" data-analytics="nav-privacy">Privacy Policy</a>
   </nav>
   <button id="theme-toggle" aria-label="Toggle theme"></button>
   <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -124,4 +124,42 @@
       });
     }
   }
+  // Scroll depth tracking
+  const scrollMarks = [25, 50, 75, 100];
+  const seenMarks = new Set();
+  const reportScroll = () => {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (docHeight <= 0) return;
+    const percent = Math.round((scrollTop / docHeight) * 100);
+    scrollMarks.forEach(mark => {
+      if (percent >= mark && !seenMarks.has(mark)) {
+        seenMarks.add(mark);
+        if (window.gtag) {
+          window.gtag('event', 'scroll', {
+            event_category: 'engagement',
+            event_label: `${mark}%`,
+          });
+        }
+      }
+    });
+    if (seenMarks.size === scrollMarks.length) {
+      window.removeEventListener('scroll', reportScroll);
+    }
+  };
+  window.addEventListener('scroll', reportScroll, { passive: true });
+
+  // Time-on-page tracking
+  const start = performance.now();
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      const duration = Math.round((performance.now() - start) / 1000);
+      if (window.gtag) {
+        window.gtag('event', 'time_on_page', {
+          event_category: 'engagement',
+          value: duration,
+        });
+      }
+    }
+  });
 })();


### PR DESCRIPTION
## Summary
- track scroll depth and time-on-page in analytics
- mark navbar and footer links with analytics labels for click-through tracking

## Testing
- `npm test` *(fails: dependency installation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b50dd4a730832cbf91de3cd78cf205