### PR TITLE
docs: document color palette

### DIFF
--- a/design/color-palette.md
+++ b/design/color-palette.md
@@ -1,0 +1,27 @@
+# Color Palette
+
+This palette allocates roughly 60% grayscale neutrals, 30% brand colors and 10% accent colors. Implementations should use the CSS variables noted below to maintain consistency and accessibility.
+
+## Grayscale Foundation (~60%)
+
+| Variable | Hex | Usage |
+| --- | --- | --- |
+| `--color-bg` | `#FFFFFF` | Primary page background. |
+| `--color-surface` | `#F5F5F5` | Card and section backgrounds. |
+| `--color-text` | `#111111` | Main body text and headings. |
+| `--color-muted` | `#666666` | Borders, metadata and muted text. |
+
+## Branding Colors (~30%)
+
+| Variable | Hex | Usage |
+| --- | --- | --- |
+| `--brand-primary` | `#1E3A8A` | Primary actions and interactive elements. |
+| `--brand-secondary` | `#0D9488` | Secondary actions and hover states. |
+
+## Accent Color (~10%)
+
+| Variable | Hex | Usage |
+| --- | --- | --- |
+| `--accent` | `#F59E0B` | Highlights and status indicators. |
+
+Dark theme variants mirror these hues with darker neutrals and lighter brand tones to preserve contrast.

--- a/theme.css
+++ b/theme.css
@@ -1,16 +1,16 @@
 :root {
   /* 60% grayscale foundation */
-  --color-bg: #f6f0ed;
-  --color-surface: #ffffff;
+  --color-bg: #ffffff;
+  --color-surface: #f5f5f5;
   --color-text: #111111;
-  --color-muted: #bbb193;
+  --color-muted: #666666;
 
   /* 30% brand colors */
-  --brand-primary: #26536b;
-  --brand-secondary: var(--color-muted);
+  --brand-primary: #1e3a8a;
+  --brand-secondary: #0d9488;
 
   /* 10% accent color */
-  --accent: #c2948a;
+  --accent: #f59e0b;
 
   --navbar-height: calc(env(safe-area-inset-top) + 5rem);
 
@@ -24,13 +24,13 @@
 
 :root[data-theme="dark"] {
   --color-bg: #111111;
-  --color-surface: #1a1a1a;
-  --color-text: #f6f0ed;
-  --color-muted: #444444;
+  --color-surface: #1f1f1f;
+  --color-text: #f5f5f5;
+  --color-muted: #999999;
 
-  --brand-primary: #7ea8be;
-  --brand-secondary: var(--color-muted);
-  --accent: #e4b6ad;
+  --brand-primary: #60a5fa;
+  --brand-secondary: #5eead4;
+  --accent: #fbbf24;
 }
 
 body {


### PR DESCRIPTION
## Summary
- define grayscale, brand and accent color palette in design docs
- update theme variables to match selected palette

## Testing
- `npm test` *(fails: required Playwright dependencies installation did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68b517472e40832c8fb3ebaad408d5ba