### PR TITLE
feat: refresh brand and accent color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ Brand colors are centralized as CSS variables in `style.css`. Adjust the values 
 
 ```css
 :root {
-  --color-primary: #1e3c72;
-  --color-secondary: #2a5298;
-  --color-accent: #f28c2f;
+  --color-primary: #2563eb;
+  --color-secondary: #14b8a6;
+  --color-accent: #f97316;
 }
 ```
 

--- a/design/color-palette.md
+++ b/design/color-palette.md
@@ -6,22 +6,22 @@ This palette allocates roughly 60% grayscale neutrals, 30% brand colors and 10% 
 
 | Variable | Hex | Usage |
 | --- | --- | --- |
-| `--color-bg` | `#FFFFFF` | Primary page background. |
-| `--color-surface` | `#F5F5F5` | Card and section backgrounds. |
-| `--color-text` | `#111111` | Main body text and headings. |
-| `--color-muted` | `#666666` | Borders, metadata and muted text. |
+| `--color-bg` | `#FAFAFA` | Primary page background. |
+| `--color-surface` | `#E5E5E5` | Card and section backgrounds. |
+| `--color-text` | `#222222` | Main body text and headings. |
+| `--color-muted` | `#888888` | Borders, metadata and muted text. |
 
 ## Branding Colors (~30%)
 
 | Variable | Hex | Usage |
 | --- | --- | --- |
-| `--brand-primary` | `#1E3A8A` | Primary actions and interactive elements. |
-| `--brand-secondary` | `#0D9488` | Secondary actions and hover states. |
+| `--brand-primary` | `#2563EB` | Primary actions and interactive elements. |
+| `--brand-secondary` | `#14B8A6` | Secondary actions and hover states. |
 
 ## Accent Color (~10%)
 
 | Variable | Hex | Usage |
 | --- | --- | --- |
-| `--accent` | `#F59E0B` | Highlights and status indicators. |
+| `--accent` | `#F97316` | Highlights and status indicators. |
 
 Dark theme variants mirror these hues with darker neutrals and lighter brand tones to preserve contrast.

--- a/theme.css
+++ b/theme.css
@@ -1,16 +1,16 @@
 :root {
   /* 60% grayscale foundation */
-  --color-bg: #ffffff;
-  --color-surface: #f5f5f5;
-  --color-text: #111111;
-  --color-muted: #666666;
+  --color-bg: #fafafa;
+  --color-surface: #e5e5e5;
+  --color-text: #222222;
+  --color-muted: #888888;
 
   /* 30% brand colors */
-  --brand-primary: #1e3a8a;
-  --brand-secondary: #0d9488;
+  --brand-primary: #2563eb;
+  --brand-secondary: #14b8a6;
 
   /* 10% accent color */
-  --accent: #f59e0b;
+  --accent: #f97316;
 
   --navbar-height: calc(env(safe-area-inset-top) + 5rem);
 
@@ -23,14 +23,14 @@
 }
 
 :root[data-theme="dark"] {
-  --color-bg: #111111;
-  --color-surface: #1f1f1f;
+  --color-bg: #0a0a0a;
+  --color-surface: #1a1a1a;
   --color-text: #f5f5f5;
-  --color-muted: #999999;
+  --color-muted: #a3a3a3;
 
-  --brand-primary: #60a5fa;
-  --brand-secondary: #5eead4;
-  --accent: #fbbf24;
+  --brand-primary: #3b82f6;
+  --brand-secondary: #065a43;
+  --accent: #9a3412;
 }
 
 body {


### PR DESCRIPTION
## Summary
- update light and dark theme CSS variables with new palette
- refresh color palette documentation and README snippet

## Testing
- `npm test` *(fails: sold page layout should match snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68b519791150832cb8ba90b103d0366f