### PR TITLE
fix: improve color contrast for accessibility

### DIFF
--- a/design/color-palette.md
+++ b/design/color-palette.md
@@ -16,12 +16,12 @@ This palette allocates roughly 60% grayscale neutrals, 30% brand colors and 10% 
 | Variable | Hex | Usage |
 | --- | --- | --- |
 | `--brand-primary` | `#2563EB` | Primary actions and interactive elements. |
-| `--brand-secondary` | `#14B8A6` | Secondary actions and hover states. |
+| `--brand-secondary` | `#0F766E` | Secondary actions and hover states. |
 
 ## Accent Color (~10%)
 
 | Variable | Hex | Usage |
 | --- | --- | --- |
-| `--accent` | `#F97316` | Highlights and status indicators. |
+| `--accent` | `#B45309` | Highlights and status indicators. |
 
 Dark theme variants mirror these hues with darker neutrals and lighter brand tones to preserve contrast.

--- a/theme.css
+++ b/theme.css
@@ -12,12 +12,12 @@
   /* 30% brand colors */
   --brand-primary: #2563eb;
   --brand-primary-rgb: 37, 99, 235;
-  --brand-secondary: #14b8a6;
-  --brand-secondary-rgb: 20, 184, 166;
+  --brand-secondary: #0f766e;
+  --brand-secondary-rgb: 15, 118, 110;
 
   /* 10% accent color */
-  --accent: #f97316;
-  --accent-rgb: 249, 115, 22;
+  --accent: #b45309;
+  --accent-rgb: 180, 83, 9;
 
   --navbar-height: calc(env(safe-area-inset-top) + 5rem);
 
@@ -46,10 +46,10 @@
 
   --brand-primary: #3b82f6;
   --brand-primary-rgb: 59, 130, 246;
-  --brand-secondary: #065a43;
-  --brand-secondary-rgb: 6, 90, 67;
-  --accent: #9a3412;
-  --accent-rgb: 154, 52, 18;
+  --brand-secondary: #0d9488;
+  --brand-secondary-rgb: 13, 148, 136;
+  --accent: #f97316;
+  --accent-rgb: 249, 115, 22;
 }
 
 body {


### PR DESCRIPTION
## Summary
- darken secondary brand color and accent to satisfy WCAG AA contrast
- document updated color values in design palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b51e8759b4832cbe810091ea73caad