### PR TITLE
Rename testimonials nav link to Customer Reviews

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -3,7 +3,7 @@
     <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
   </a>
   <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-        <a href="#testimonials" data-analytics="nav-testimonials">Success Stories</a>
+        <a href="#testimonials" data-analytics="nav-reviews">Customer Reviews</a>
         <a href="#story" data-analytics="nav-story">Our Story</a>
         <a href="#approach" data-analytics="nav-approach">Built on Trust</a>
     <a href="#ebay" data-analytics="nav-ebay">eBay</a>

--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -6,7 +6,7 @@
     <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
   </a>
   <nav id="nav-menu" class="nav-menu" aria-hidden="true">
-        <a href="#testimonials">Success Stories</a>
+        <a href="#testimonials" data-analytics="nav-reviews">Customer Reviews</a>
         <a href="#story">Our Story</a>
         <a href="#approach">Built on Trust</a>
     <a href="#ebay">eBay</a>

--- a/tests/navbar-links.spec.ts
+++ b/tests/navbar-links.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const filePath = path.resolve(__dirname, '../index.html');
 
-const expected = ['Success Stories', 'Our Story', 'Built on Trust', 'eBay', 'OfferUp', 'Subscribe', 'Business Inquiries'];
+const expected = ['Customer Reviews', 'Our Story', 'Built on Trust', 'eBay', 'OfferUp', 'Subscribe', 'Business Inquiries'];
 
 test('navbar links are in expected order', async ({ page }) => {
   await page.goto('file://' + filePath);


### PR DESCRIPTION
## Summary
- rename navbar link from "Success Stories" to "Customer Reviews" and update analytics key to `nav-reviews`
- sync inline navbar template with updated link and analytics key
- adjust navigation link test expectations for the new label

## Testing
- `npm test` *(failed: sold page layout should match snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1a49f50832c91dab95347f00719