### PR TITLE
Honor reduced-motion user preference

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,6 +43,26 @@ body {
   color: var(--color-text);
   overflow-x: hidden;
 }
+@media (prefers-reduced-motion: reduce) {
+  body {
+    animation: none;
+  }
+  .story-bg-animate,
+  .approach-bg-animate {
+    animation: none;
+    background-size: 100% 100%;
+  }
+  .scroll-cue,
+  .dotted-loader,
+  .feature-marquee li,
+  .skeleton-chart,
+  .skeleton-table,
+  .ripple,
+  .form-msg.success,
+  .form-msg.error {
+    animation: none;
+  }
+}
 @keyframes bg-shift {
   0%,
   100% {


### PR DESCRIPTION
## Summary
- Disable animations for users who prefer reduced motion
- Turn off background, marquee, loader, and other animation effects when reduced motion is requested

## Testing
- `npm test` *(fails: sold page layout should match snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eb3c5dbc832cb7cc7f5c5cc1f572