### PR TITLE
feat: default theme to system preference

### DIFF
--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -49,8 +49,12 @@
 
   let storedTheme = 'light';
   try {
-    storedTheme = localStorage.getItem('theme') || 'light';
-  } catch {}
+    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    storedTheme = localStorage.getItem('theme') || (systemDark ? 'dark' : 'light');
+  } catch {
+    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    storedTheme = systemDark ? 'dark' : 'light';
+  }
   const applyTheme = (t) => {
     root.setAttribute('data-theme', t);
     if (themeToggle) {


### PR DESCRIPTION
## Summary
- detect system color scheme when no theme is stored to choose dark or light

## Testing
- `npm test` *(fails: command interrupted during Playwright dependencies installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b8690981b8832c85a27b988abfec65