### PR TITLE
feat: trap focus in cookie banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
 
   <div data-include="partials/footer.html"></div>
 
-  <div id="cookie-banner" class="cookie-banner hidden" role="dialog" aria-live="polite">
+  <div id="cookie-banner" class="cookie-banner hidden" role="dialog" aria-modal="true">
     <span>This site uses cookies and analytics to improve your experience.</span>
     <button id="cookie-btn">OK</button>
   </div>

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -116,15 +116,26 @@
   });
   const cookieBanner = document.getElementById('cookie-banner');
   const cookieBtn = document.getElementById('cookie-btn');
-  if(cookieBanner && cookieBtn){
-    if(localStorage.getItem('cookieConsent')){
+  if (cookieBanner && cookieBtn) {
+    if (localStorage.getItem('cookieConsent')) {
       cookieBanner.remove();
-    }else{
+    } else {
+      const prevFocus = document.activeElement;
       cookieBanner.classList.remove('hidden');
+      cookieBtn.focus();
+      const trapFocus = (e) => {
+        if (e.key === 'Tab') {
+          e.preventDefault();
+          cookieBtn.focus();
+        }
+      };
+      document.addEventListener('keydown', trapFocus);
       cookieBtn.addEventListener('click', () => {
-        localStorage.setItem('cookieConsent','yes');
+        localStorage.setItem('cookieConsent', 'yes');
+        document.removeEventListener('keydown', trapFocus);
         cookieBanner.remove();
-        if(window.gtag){ window.gtag('event','cookie_consent'); }
+        prevFocus?.focus?.();
+        if (window.gtag) { window.gtag('event', 'cookie_consent'); }
       });
     }
   }


### PR DESCRIPTION
## Summary
- mark cookie banner as modal dialog
- trap focus within cookie banner and restore prior focus when dismissed

## Testing
- `npm test` *(fails: menu.spec.ts and sold-visual.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8820bc494832c9aaea588357ffa88