### PR TITLE
Remove static aria-expanded from policy summaries

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -43,23 +43,23 @@
       </ol>
     </nav>
     <details id="orders-shipping">
-      <summary aria-expanded="false">Orders & Shipping</summary>
+      <summary>Orders & Shipping</summary>
       <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>
     </details>
     <details id="returns-refunds">
-      <summary aria-expanded="false">Returns & Refunds</summary>
+      <summary>Returns & Refunds</summary>
       <p>Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method once items are received.</p>
     </details>
     <details id="customer-support">
-      <summary aria-expanded="false">Customer Support</summary>
+      <summary>Customer Support</summary>
       <p>I respond to all messages within 24 hours. You have the right to prompt assistance with any order issue.</p>
     </details>
     <details id="payments-pricing">
-      <summary aria-expanded="false">Payments & Pricing</summary>
+      <summary>Payments & Pricing</summary>
       <p>Payments are processed securely, and pricing reflects any applicable taxes or fees. Accepted methods include major credit cards and PayPal.</p>
     </details>
     <details id="product-information">
-      <summary aria-expanded="false">Product Information</summary>
+      <summary>Product Information</summary>
       <p>All items are described accurately with detailed photos. Contact me for any additional information about condition or provenance.</p>
     </details>
   </main>

--- a/privacy.html
+++ b/privacy.html
@@ -86,35 +86,35 @@
       </ol>
     </nav>
     <details id="information-we-collect">
-      <summary aria-expanded="false">Information We Collect</summary>
+      <summary>Information We Collect</summary>
       <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>
     </details>
     <details id="how-we-use-information">
-      <summary aria-expanded="false">How We Use Information</summary>
+      <summary>How We Use Information</summary>
       <p>Information is used to send updates, respond to inquiries, and enhance site performance. Cookies may be stored on your device to support these functions, and we do not sell or share your information with third parties except as required by law.</p>
     </details>
     <details id="cookie-usage">
-      <summary aria-expanded="false">Cookie Usage</summary>
+      <summary>Cookie Usage</summary>
       <p>We use essential and analytics cookies to remember your preferences and understand site traffic. You can control cookies through your browser settings.</p>
     </details>
     <details id="analytics-tools">
-      <summary aria-expanded="false">Analytics Tools</summary>
+      <summary>Analytics Tools</summary>
       <p>We use privacy-focused analytics tools to measure visits and performance. These tools collect aggregated data and store it for up to 24 months.</p>
     </details>
     <details id="data-sharing">
-      <summary aria-expanded="false">Data Sharing</summary>
+      <summary>Data Sharing</summary>
       <p>Personal information is not sold. Data may be shared with service providers that help operate the site or as required by law.</p>
     </details>
     <details id="opt-out-options">
-      <summary aria-expanded="false">Opt-Out Options</summary>
+      <summary>Opt-Out Options</summary>
       <p>You can opt out of analytics by blocking cookies or using browser extensions. To stop receiving emails or remove your information, use unsubscribe links or contact us.</p>
     </details>
     <details id="data-retention">
-      <summary aria-expanded="false">Data Retention</summary>
+      <summary>Data Retention</summary>
       <p>Mailing list data is kept until you unsubscribe or request deletion. Aggregated analytics data is retained for up to 24 months to help improve the site.</p>
     </details>
     <details id="your-rights-and-data-requests">
-      <summary aria-expanded="false">Your Rights and Data Requests</summary>
+      <summary>Your Rights and Data Requests</summary>
       <p>You have the right to access, correct, or erase your personal information. For data requests or questions, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
     </details>
   </main>

--- a/returns.html
+++ b/returns.html
@@ -43,12 +43,12 @@
       </ol>
     </nav>
     <details id="shipping-policy">
-      <summary aria-expanded="false">Shipping Policy</summary>
+      <summary>Shipping Policy</summary>
       <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>
       <p>For common questions about delivery, see the <a href="faq.html#orders-shipping">Orders &amp; Shipping FAQ</a>.</p>
     </details>
     <details id="returns-policy">
-      <summary aria-expanded="false">Returns Policy</summary>
+      <summary>Returns Policy</summary>
       <p>Returns are accepted within 30 days of delivery. Items must be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
       <h2 id="initiating-a-return">Initiating a Return</h2>
       <p>To start a return, reach out via the <a href="index.html#contact">contact form</a> with your order details. I will provide instructions within 24 hours.</p>
@@ -59,15 +59,15 @@
       <p>Additional details are available in the <a href="faq.html#returns-refunds">Returns &amp; Refunds FAQ</a>.</p>
     </details>
     <details id="refund-exceptions">
-      <summary aria-expanded="false">Refund Exceptions</summary>
+      <summary>Refund Exceptions</summary>
       <p>Custom or personalized orders and digital items are non-refundable unless defective. Shipping costs are non-refundable once an order has shipped.</p>
     </details>
     <details id="customer-rights">
-      <summary aria-expanded="false">Customer Rights</summary>
+      <summary>Customer Rights</summary>
       <p>You may request an exchange or refund for eligible items. If a dispute arises, you have the right to seek resolution through your payment provider or applicable consumer protection laws.</p>
     </details>
     <details id="communication-expectations">
-      <summary aria-expanded="false">Communication Expectations</summary>
+      <summary>Communication Expectations</summary>
       <p>I strive to answer all messages within 24 hours. Reach out with any order questions and I'll work to make things right.</p>
     </details>
   </main>


### PR DESCRIPTION
## Summary
- Remove `aria-expanded` from FAQ and policy `<summary>` elements
- Rely on analytics script to toggle `aria-expanded` dynamically

## Testing
- `npm test` *(fails: menu keyboard navigation, sold page snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68b883bf75f4832c9e9aaf16ec576bcd