### PR TITLE
Improve carousel accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
           <div class="featured">
             <h3>Collector Favorites</h3>
             <p class="promo">What you get: handpicked collectibles with fast, tracked shipping.</p>
-            <div class="carousel">
+            <div class="carousel" role="region" aria-label="eBay featured items">
               <button class="carousel-btn carousel-prev" aria-label="Previous"><i class="fa-solid fa-chevron-left" aria-hidden="true"></i></button>
               <div class="featured-items" id="ebay-items"></div>
               <button class="carousel-btn carousel-next" aria-label="Next"><i class="fa-solid fa-chevron-right" aria-hidden="true"></i></button>
@@ -276,7 +276,7 @@
           <div class="featured">
             <h3>Collector Favorites</h3>
             <p class="promo">What you get: local finds ready for same-day pickup.</p>
-            <div class="carousel">
+            <div class="carousel" role="region" aria-label="OfferUp featured items">
               <button class="carousel-btn carousel-prev" aria-label="Previous"><i class="fa-solid fa-chevron-left" aria-hidden="true"></i></button>
               <div class="featured-items" id="offerup-items"></div>
               <button class="carousel-btn carousel-next" aria-label="Next"><i class="fa-solid fa-chevron-right" aria-hidden="true"></i></button>

--- a/scripts/animations.js
+++ b/scripts/animations.js
@@ -108,21 +108,30 @@
       const next = carousel.querySelector('.carousel-next');
       const items = track ? Array.from(track.querySelectorAll('a')) : [];
       if (!items.length) return;
+      track.setAttribute('aria-live', 'polite');
       let idx = 0;
+      const updateAria = () => {
+        items.forEach((el, i) => el.setAttribute('aria-hidden', i !== idx));
+        track.setAttribute('aria-label', `Slide ${idx + 1} of ${items.length}`);
+      };
       const go = (i) => {
         idx = (i + items.length) % items.length;
         const item = items[idx];
         const offset = item.offsetLeft + item.offsetWidth / 2 - track.clientWidth / 2;
         track.scrollTo({ left: offset, behavior: 'smooth' });
+        updateAria();
       };
-      prev?.addEventListener('click', () => {
+      updateAria();
+      prev?.addEventListener('click', (e) => {
         go(idx - 1);
+        e.currentTarget.focus();
         if (window.gtag) {
           window.gtag('event','carousel_nav',{event_label:'prev'});
         }
       });
-      next?.addEventListener('click', () => {
+      next?.addEventListener('click', (e) => {
         go(idx + 1);
+        e.currentTarget.focus();
         if (window.gtag) {
           window.gtag('event','carousel_nav',{event_label:'next'});
         }


### PR DESCRIPTION
## Summary
- Add region role and labels to featured carousels
- Mark non-visible carousel items as aria-hidden and announce active slide via aria-live
- Maintain focus on navigation buttons for better keyboard usability

## Testing
- `npm test` *(fails: sold page snapshot mismatch, menu keyboard navigation issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b88919551c832ca09cd577729d3aef