### PR TITLE
feat(theme): add feedback color tokens

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,6 +32,14 @@ Use the CSS variables below to keep styles consistent across components and to e
 | --- | --- | --- |
 | `--accent` | `#B45309` | Highlights and status indicators. |
 
+### Status Colors
+
+| Variable | Hex | Usage |
+| --- | --- | --- |
+| `--color-success` | `#16A34A` | Success messages and positive indicators. |
+| `--color-warning` | `#D97706` | Cautionary notes or items needing attention. |
+| `--color-error` | `#DC2626` | Errors and destructive actions. |
+
 Neutrals keep layouts readable while the brand colors guide focus. The accent is intentionally sparing so callouts remain noticeable.
 
 ## Usage

--- a/style.css
+++ b/style.css
@@ -698,11 +698,11 @@ summary:focus {
     color: var(--color-muted);
   }
   .form-msg.success {
-    color: var(--color-primary);
+    color: var(--color-success);
     animation: fade-in 0.3s ease;
   }
 .form-msg.error {
-  color: var(--color-primary);
+  color: var(--color-error);
   font-weight: 700;
   animation: fade-in 0.3s ease;
 }

--- a/theme.css
+++ b/theme.css
@@ -19,6 +19,13 @@
   --accent: #c2410c;
   --accent-rgb: 194, 65, 12;
 
+  --color-success: #16a34a;
+  --color-success-rgb: 22, 163, 74;
+  --color-warning: #d97706;
+  --color-warning-rgb: 217, 119, 6;
+  --color-error: #dc2626;
+  --color-error-rgb: 220, 38, 38;
+
   --navbar-height: calc(env(safe-area-inset-top) + 5rem);
 
   /* legacy aliases */
@@ -50,6 +57,13 @@
   --brand-secondary-rgb: 13, 148, 136;
   --accent: #ea580c;
   --accent-rgb: 234, 88, 12;
+
+  --color-success: #22c55e;
+  --color-success-rgb: 34, 197, 94;
+  --color-warning: #f59e0b;
+  --color-warning-rgb: 245, 158, 11;
+  --color-error: #ef4444;
+  --color-error-rgb: 239, 68, 68;
 }
 
 body {


### PR DESCRIPTION
## Summary
- add success, warning, and error color tokens with light/dark variants
- use new tokens for form message styles
- document feedback color usage in design guide

## Testing
- `npm test` *(fails: menu keyboard navigation and sold page layout snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c7bb8f2c832cb52124d259dc7cdb