### PR TITLE
Use fixed overlay color for dark mode contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,7 +95,7 @@ section::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(var(--black-rgb), 0.7);
+  background: rgba(0, 0, 0, 0.7);
   z-index: 0;
 }
 
@@ -104,7 +104,7 @@ section + section {
 }
 
 section:nth-of-type(even)::after {
-  background: rgba(var(--black-rgb), 0.6);
+  background: rgba(0, 0, 0, 0.6);
 }
 .section-content {
   position: relative;


### PR DESCRIPTION
## Summary
- Ensure section overlays use a hard-coded dark background instead of theme text color

## Testing
- `npm test` *(fails: installation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b92df83828832ca7c3a20f363fb326