### PR TITLE
Add high contrast theme and cycle toggle

### DIFF
--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -47,26 +47,35 @@
     });
   }
 
+  const themes = ['light', 'dark', 'hc'];
   let storedTheme = 'light';
   try {
     const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     storedTheme = localStorage.getItem('theme') || (systemDark ? 'dark' : 'light');
+    if (!themes.includes(storedTheme)) storedTheme = 'light';
   } catch {
     const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     storedTheme = systemDark ? 'dark' : 'light';
   }
+  const nextIcon = {
+    light: '🌙',
+    dark: '🔳',
+    hc: '☀️',
+  };
   const applyTheme = (t) => {
     root.setAttribute('data-theme', t);
     if (themeToggle) {
-      themeToggle.textContent = t === 'light' ? '🌙' : '☀️';
+      themeToggle.textContent = nextIcon[t];
     }
   };
   applyTheme(storedTheme);
   themeToggle?.addEventListener('click', () => {
-    const current = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
-    applyTheme(current);
+    const current = root.getAttribute('data-theme') || 'light';
+    const index = themes.indexOf(current);
+    const next = themes[(index + 1) % themes.length];
+    applyTheme(next);
     try {
-      localStorage.setItem('theme', current);
+      localStorage.setItem('theme', next);
     } catch {}
   });
 

--- a/theme.css
+++ b/theme.css
@@ -66,6 +66,17 @@
   --color-error-rgb: 239, 68, 68;
 }
 
+:root[data-theme="hc"] {
+  --color-bg: #000;
+  --color-bg-rgb: 0, 0, 0;
+  --color-surface: #000;
+  --color-surface-rgb: 0, 0, 0;
+  --color-text: #fff;
+  --color-text-rgb: 255, 255, 255;
+  --color-muted: #fff;
+  --color-muted-rgb: 255, 255, 255;
+}
+
 body {
   background: linear-gradient(
     to bottom,
@@ -114,23 +125,28 @@ body.fade-out {
   opacity: 0;
 }
 
-[data-theme="dark"] .navbar {
+[data-theme="dark"] .navbar,
+[data-theme="hc"] .navbar {
   background: rgba(var(--black-rgb), 0.45);
 }
 
-[data-theme="dark"] .nav-menu {
+[data-theme="dark"] .nav-menu,
+[data-theme="hc"] .nav-menu {
   background: rgba(var(--color-surface-rgb), 0.85);
 }
 
-[data-theme="dark"] .nav-menu a {
+[data-theme="dark"] .nav-menu a,
+[data-theme="hc"] .nav-menu a {
   color: var(--color-text);
 }
 
-[data-theme="dark"] .line {
+[data-theme="dark"] .line,
+[data-theme="hc"] .line {
   background: var(--color-text);
 }
 
-[data-theme="dark"] #theme-toggle {
+[data-theme="dark"] #theme-toggle,
+[data-theme="hc"] #theme-toggle {
   color: var(--color-text);
 }
 


### PR DESCRIPTION
## Summary
- add high contrast CSS theme using black background and white text
- update theme toggle to cycle among light, dark, and high-contrast modes
- persist chosen theme in localStorage

## Testing
- `npm test` *(fails: 6 failed, 106 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a1443298832caa8352c4c3cc45b5