### PR TITLE
Add aria-expanded toggle for product search suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
   <!-- Product Search -->
   <form id="search-form" role="search">
     <label for="product-search" class="sr-only">Search products</label>
-    <input id="product-search" type="search" placeholder="Search products" autocomplete="off" aria-label="Search products" aria-controls="search-suggestions" aria-autocomplete="list">
+    <input id="product-search" type="search" placeholder="Search products" autocomplete="off" aria-label="Search products" aria-controls="search-suggestions" aria-autocomplete="list" aria-expanded="false">
     <ul id="search-suggestions" role="listbox" aria-label="Search suggestions" aria-live="polite"></ul>
   </form>
 

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -9,6 +9,7 @@ if (input && suggestions) {
     suggestions.innerHTML = '';
     highlighted = -1;
     input.removeAttribute('aria-activedescendant');
+    input.setAttribute('aria-expanded', 'false');
   };
 
   const updateHighlight = () => {
@@ -94,6 +95,9 @@ if (input && suggestions) {
       console.info('No search results for', query);
     }
     updateHighlight();
+      if (suggestions.childElementCount > 0) {
+        input.setAttribute('aria-expanded', 'true');
+      }
   });
 
   input.addEventListener('blur', () => setTimeout(clearSuggestions, 100));


### PR DESCRIPTION
## Summary
- mark product search input with `aria-expanded` by default
- toggle `aria-expanded` in search suggestions for accessibility

## Testing
- `npm test` *(fails: sold-layout snapshots and menu keyboard navigation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27d8d9a0832c80ca24f8027016e8