### PR TITLE
Add aria-pressed state for theme toggle

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -15,7 +15,7 @@
     <a href="returns.html" data-analytics="nav-returns">Returns</a>
     <a href="privacy.html" data-analytics="nav-privacy">Privacy Policy</a>
   </nav>
-  <button id="theme-toggle" aria-label="Toggle theme"></button>
+  <button id="theme-toggle" aria-label="Toggle theme" aria-pressed="false"></button>
   <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
     <span class="line" aria-hidden="true"></span>
     <span class="line" aria-hidden="true"></span>

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -66,6 +66,7 @@
     root.setAttribute('data-theme', t);
     if (themeToggle) {
       themeToggle.textContent = nextIcon[t];
+      themeToggle.setAttribute('aria-pressed', t === 'light' ? 'false' : 'true');
     }
   };
   applyTheme(storedTheme);

--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -18,7 +18,7 @@
     <a href="returns.html">Returns</a>
     <a href="privacy.html">Privacy Policy</a>
   </nav>
-  <button id="theme-toggle" aria-label="Toggle theme"></button>
+  <button id="theme-toggle" aria-label="Toggle theme" aria-pressed="false"></button>
   <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">
     <span class="line" aria-hidden="true"></span>
     <span class="line" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- expose theme toggle state via `aria-pressed`
- update theme application logic to sync `aria-pressed`
- sync inline template for navbar

## Testing
- `npm test` *(fails: terminated during system dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bd31bc5a68832c9ccc922c51c46ad9