### PR TITLE
Hide feature marquee from screen readers

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,8 +177,8 @@
               <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn secondary-cta" data-analytics="offerup" data-share-link>Browse OfferUp</a>
             </div>
         </div>
-        <div class="feature-marquee-container">
-          <ul class="feature-marquee">
+        <div class="feature-marquee-container" aria-hidden="true">
+          <ul class="feature-marquee" aria-hidden="true">
             <li>Trusted seller</li>
             <li>Fast shipping</li>
             <li>Collector-friendly pricing</li>


### PR DESCRIPTION
## Summary
- hide decorative feature marquee from screen readers via `aria-hidden="true"`

## Testing
- `npm test` *(fails: menu keyboard navigation tests and sold page layout snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a65d8134832c93e81e86594456d0