### PR TITLE
Make navigation visible without JavaScript

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -2,7 +2,7 @@
   <a href="#home" class="brand" data-analytics="nav-home">
     <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
   </a>
-  <nav id="nav-menu" class="nav-menu" aria-hidden="true">
+  <nav id="nav-menu" class="nav-menu">
         <a href="#testimonials" data-analytics="nav-reviews">Customer Reviews</a>
         <a href="#story" data-analytics="nav-story">Our Story</a>
         <a href="#approach" data-analytics="nav-approach">Built on Trust</a>

--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -2,21 +2,21 @@
   const isHome = location.pathname === '/' || location.pathname.endsWith('/index.html');
   const templates = {
     'partials/navbar.html': `<header class="navbar">
-  <a href="#home" class="brand">
+  <a href="#home" class="brand" data-analytics="nav-home">
     <img src="logo.svg" alt="HecCollects logo" width="40" height="40">
   </a>
-  <nav id="nav-menu" class="nav-menu" aria-hidden="true">
+  <nav id="nav-menu" class="nav-menu">
         <a href="#testimonials" data-analytics="nav-reviews">Customer Reviews</a>
-        <a href="#story">Our Story</a>
-        <a href="#approach">Built on Trust</a>
-    <a href="#ebay">eBay</a>
-    <a href="#offerup">OfferUp</a>
-    <a href="#subscribe">Subscribe</a>
-    <a href="#contact">Business Inquiries</a>
-    <a href="sold.html">Sold Listings</a>
-    <a href="faq.html">FAQ</a>
-    <a href="returns.html">Returns</a>
-    <a href="privacy.html">Privacy Policy</a>
+        <a href="#story" data-analytics="nav-story">Our Story</a>
+        <a href="#approach" data-analytics="nav-approach">Built on Trust</a>
+    <a href="#ebay" data-analytics="nav-ebay">eBay</a>
+    <a href="#offerup" data-analytics="nav-offerup">OfferUp</a>
+    <a href="#subscribe" data-analytics="nav-subscribe">Subscribe</a>
+    <a href="#contact" data-analytics="nav-contact">Business Inquiries</a>
+    <a href="sold.html" data-analytics="nav-sold">Sold Listings</a>
+    <a href="faq.html" data-analytics="nav-faq">FAQ</a>
+    <a href="returns.html" data-analytics="nav-returns">Returns</a>
+    <a href="privacy.html" data-analytics="nav-privacy">Privacy Policy</a>
   </nav>
   <button id="theme-toggle" aria-label="Toggle theme" aria-pressed="false"></button>
   <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -2,8 +2,13 @@
   const burger = document.querySelector('.nav-toggle');
   const navMenu = document.getElementById('nav-menu');
 
+  if (navMenu) {
+    navMenu.classList.add('nav-menu-ready');
+  }
+
   if (burger && navMenu) {
     const links = Array.from(navMenu.querySelectorAll('a'));
+    let currentLinkIndex = -1;
     const mql = window.matchMedia('(min-width: 1024px)');
 
     const openMenu = () => {
@@ -13,6 +18,7 @@
       navMenu.setAttribute('aria-hidden', 'false');
       document.body.style.overflow = 'hidden';
       links[0]?.focus();
+      currentLinkIndex = links.length ? 0 : -1;
       if (window.gtag) {
         window.gtag('event', 'menu_open');
       }
@@ -25,6 +31,7 @@
       navMenu.classList.remove('open');
       burger.setAttribute('aria-expanded', 'false');
       navMenu.setAttribute('aria-hidden', 'true');
+      currentLinkIndex = -1;
       if (focusBurger) burger.focus();
       if (window.gtag) {
         window.gtag('event', 'menu_close');
@@ -39,7 +46,10 @@
       }
     });
 
-    links.forEach(link => {
+    links.forEach((link, index) => {
+      link.addEventListener('focus', () => {
+        currentLinkIndex = index;
+      });
       link.addEventListener('click', () => {
         closeMenu(false);
         if (window.gtag) {
@@ -57,15 +67,17 @@
       if (e.key === 'Escape') {
         closeMenu();
       } else if (e.key === 'Tab' && links.length) {
-        const first = links[0];
-        const last = links[links.length - 1];
+        e.preventDefault();
+        const activeIndex = currentLinkIndex >= 0 ? currentLinkIndex : links.findIndex(link => link === document.activeElement);
 
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
+        if (e.shiftKey) {
+          const prevIndex = activeIndex > 0 ? activeIndex - 1 : links.length - 1;
+          links[prevIndex]?.focus();
+          currentLinkIndex = prevIndex;
+        } else {
+          const nextIndex = activeIndex >= 0 && activeIndex < links.length - 1 ? activeIndex + 1 : 0;
+          links[nextIndex]?.focus();
+          currentLinkIndex = nextIndex;
         }
       }
     });

--- a/style.css
+++ b/style.css
@@ -839,10 +839,15 @@ summary:focus {
 }
 /* Overlay Menu (desktop & mobile) */
 .nav-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+.nav-menu.nav-menu-ready {
   position: fixed;
   inset: 0;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 2.4rem;
@@ -860,7 +865,7 @@ summary:focus {
     opacity 0.3s;
   z-index: 10001;
 }
-.nav-menu.open {
+.nav-menu.nav-menu-ready.open {
   transform: translateY(0);
   pointer-events: auto;
   opacity: 1;
@@ -928,13 +933,16 @@ summary:focus {
     display: none;
   }
   .nav-menu {
+    flex-direction: row;
+    gap: 2rem;
+    background: none;
+    padding: 0;
+  }
+  .nav-menu.nav-menu-ready {
     position: static;
     transform: none;
     opacity: 1;
     pointer-events: auto;
-    flex-direction: row;
-    gap: 2rem;
-    background: none;
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     box-shadow: none;


### PR DESCRIPTION
## Summary
- remove the static `aria-hidden` attribute from the navbar markup and inline template so the links render when JavaScript is unavailable
- update the menu script to add the overlay class at runtime, manage accessibility state, and keep focus trapped while the menu is open
- adjust the navigation styles so the menu displays by default and only uses the overlay treatment after JavaScript initializes

## Testing
- npm test -- tests/menu.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf7c22d114832c854416eb3b21b137