### PR TITLE
Add featured items fallback message

### DIFF
--- a/scripts/animations.js
+++ b/scripts/animations.js
@@ -163,8 +163,17 @@
       .then(data => {
         const buildItems = (key, containerId) => {
           const container = document.getElementById(containerId);
-          if (!container || !data[key]) return;
-          data[key].forEach((item, i) => {
+          if (!container) return;
+          const items = Array.isArray(data[key]) ? data[key] : [];
+          container.innerHTML = '';
+          if (!items.length) {
+            const fallback = document.createElement('p');
+            fallback.className = 'featured-empty';
+            fallback.textContent = 'No featured items available.';
+            container.appendChild(fallback);
+            return;
+          }
+          items.forEach((item, i) => {
             const link = document.createElement('a');
             link.href = item.link;
             link.target = '_blank';

--- a/style.css
+++ b/style.css
@@ -451,6 +451,21 @@ summary:focus {
     transform 0.3s,
     box-shadow 0.3s;
 }
+.featured-items .featured-empty {
+  flex: 1 0 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  min-height: 9rem;
+  border-radius: 0.8rem;
+  border: 2px dashed rgba(var(--white-rgb), 0.25);
+  background: rgba(var(--black-rgb), 0.35);
+  color: var(--color-muted);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-align: center;
+}
 .item-meta {
   position: absolute;
   top: 0.4rem;


### PR DESCRIPTION
## Summary
- add a friendly fallback message when featured item feeds are empty
- style the fallback message to align with the existing featured listings section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf89c8f960832c9b5a03258d4d33be