### PR TITLE
Limit anchor rewrites to shared navbar/footer includes

### DIFF
--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -72,14 +72,16 @@
 
   Promise.all(includePromises).then(() => {
     if (!isHome) {
-      document.querySelectorAll('a[href^="#"]').forEach(a => {
-        const href = a.getAttribute('href');
-        if (href === '#home') {
-          a.setAttribute('href', a.classList.contains('brand') ? 'index.html#home' : 'index.html');
-        } else {
-          a.setAttribute('href', `index.html${href}`);
-        }
-      });
+      document
+        .querySelectorAll('.navbar .brand[href^="#"], .nav-menu a[href^="#"], .site-footer a[href^="#"]')
+        .forEach(a => {
+          const href = a.getAttribute('href');
+          if (href === '#home') {
+            a.setAttribute('href', a.classList.contains('brand') ? 'index.html#home' : 'index.html');
+          } else {
+            a.setAttribute('href', `index.html${href}`);
+          }
+        });
       const currentPage = location.pathname.split('/').pop();
       document.querySelectorAll('.nav-menu a').forEach(a => {
         if (a.getAttribute('href') === currentPage) {

--- a/tests/policy-navigation.spec.ts
+++ b/tests/policy-navigation.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const pages = ['faq.html', 'returns.html', 'privacy.html'];
+
+const expectedNavAnchors = [
+  'index.html#testimonials',
+  'index.html#story',
+  'index.html#approach',
+  'index.html#ebay',
+  'index.html#offerup',
+  'index.html#subscribe',
+  'index.html#contact',
+];
+
+test.describe('policy page navigation', () => {
+  for (const pageName of pages) {
+    test(`${pageName} keeps in-page anchors local`, async ({ page }) => {
+      const filePath = path.resolve(__dirname, `../${pageName}`);
+      await page.goto('file://' + filePath);
+
+      await page.waitForSelector('header.navbar .brand');
+      await page.waitForFunction(() => {
+        const brand = document.querySelector<HTMLAnchorElement>('header.navbar .brand');
+        return brand?.getAttribute('href')?.startsWith('index.html');
+      });
+
+      const skipHref = await page.getAttribute('.skip-link', 'href');
+      expect(skipHref).toBe('#main');
+
+      const tocHrefs = await page.$$eval('.toc a', anchors => anchors.map(a => a.getAttribute('href')));
+      expect(tocHrefs.length).toBeGreaterThan(0);
+      tocHrefs.forEach(href => expect(href).toBeTruthy());
+      tocHrefs.forEach(href => expect(href?.startsWith('#')).toBeTruthy());
+
+      const brandHref = await page.getAttribute('header.navbar .brand', 'href');
+      expect(brandHref).toBe('index.html#home');
+
+      const navAnchorHrefs = await page.$$eval('.nav-menu a', (anchors, count) => {
+        return anchors.slice(0, count).map(a => a.getAttribute('href'));
+      }, expectedNavAnchors.length);
+      expect(navAnchorHrefs).toEqual(expectedNavAnchors);
+
+      const footerHomeHref = await page.getAttribute('footer.site-footer a', 'href');
+      expect(footerHomeHref).toBe('index.html');
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- scope the post-load hash-anchor rewrite to navbar and footer includes so other in-page links remain local
- add Playwright coverage ensuring policy pages keep skip links and TOC items on-page while nav/footer links point back to index.html

## Testing
- npm test *(fails: sold-visual.spec.ts snapshots differ from baselines)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9331473c832cb1c581827732abc3