### PR TITLE
Adjust transition timing for JS-controlled fades

### DIFF
--- a/page-transitions.js
+++ b/page-transitions.js
@@ -2,13 +2,24 @@ document.addEventListener('DOMContentLoaded', () => {
   const body = document.body;
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
+  const ensureTransitions = () => {
+    if (!body.classList.contains('js-has-transition')) {
+      body.classList.add('js-has-transition');
+    }
+  };
+
   const show = () => {
+    if (reducedMotion.matches) return;
+    ensureTransitions();
     body.classList.remove('fade-out');
     body.classList.add('fade-in');
   };
 
-  show();
-  window.addEventListener('pageshow', show);
+  window.addEventListener('pageshow', event => {
+    if (event.persisted) {
+      show();
+    }
+  });
 
   document.querySelectorAll('a[href]').forEach(link => {
     const target = link.getAttribute('target');
@@ -18,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
       link.addEventListener('click', e => {
         if (reducedMotion.matches) return;
         e.preventDefault();
+        ensureTransitions();
         body.classList.remove('fade-in');
         body.classList.add('fade-out');
         setTimeout(() => {

--- a/scripts/animations.js
+++ b/scripts/animations.js
@@ -1,6 +1,11 @@
 (() => {
   const canHover = window.matchMedia('(hover: hover)').matches;
   const webglSupported = !!window.WebGLRenderingContext;
+  const preloader = document.getElementById('preloader');
+
+  if (preloader) {
+    preloader.classList.add('js-preloader');
+  }
 
   const initListClones = () => {
     if (window.__listClonesInitialized) return;
@@ -82,10 +87,12 @@
 
   // Preloader
   window.addEventListener('load', () => {
-    const pre = document.getElementById('preloader');
-    if (pre) {
-      pre.classList.add('hide');
-      setTimeout(() => pre.remove(), 600);
+    if (preloader) {
+      preloader.classList.add('hide');
+      setTimeout(() => {
+        preloader.classList.remove('js-preloader');
+        preloader.remove();
+      }, 600);
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -1051,13 +1051,22 @@ summary:focus {
   position: fixed;
   inset: 0;
   background: var(--black);
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   z-index: 100000;
+  opacity: 0;
+  pointer-events: none;
   transition: opacity 0.6s;
 }
-#preloader.hide {
+
+#preloader.js-preloader {
+  display: flex;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#preloader.js-preloader.hide {
   opacity: 0;
   pointer-events: none;
 }

--- a/theme.css
+++ b/theme.css
@@ -85,21 +85,9 @@ body {
     var(--color-bg)
   );
   color: var(--color-text);
-  opacity: 0;
+  opacity: 1;
   position: relative;
   z-index: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  body {
-    transition: none;
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  body {
-    transition: background 0.4s ease-in-out, opacity 0.4s ease-in-out;
-  }
 }
 
 body::before {
@@ -117,12 +105,34 @@ body::before {
   opacity: 0.6;
 }
 
-body.fade-in {
-  opacity: 1;
+body.js-has-transition::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    var(--color-bg),
+    var(--color-surface),
+    var(--color-bg)
+  );
+  opacity: 0;
+  pointer-events: none;
 }
 
-body.fade-out {
-  opacity: 0;
+@media (prefers-reduced-motion: reduce) {
+  body.js-has-transition::after {
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  body.js-has-transition::after {
+    transition: opacity 0.4s ease-in-out;
+  }
+}
+
+body.js-has-transition.fade-out::after {
+  opacity: 1;
 }
 
 [data-theme="dark"] .navbar,


### PR DESCRIPTION
## Summary
- keep the page readable without JavaScript by making the body opacity defaults static
- gate the fade effect behind a `js-has-transition` class and drive it with an overlay instead of the body element
- default the preloader to hidden styles and let the animation script toggle a `js-preloader` class when needed

## Testing
- npm test *(fails: sold page layout snapshot mismatch appears to be present even on the base branch)*

------
https://chatgpt.com/codex/tasks/task_e_68d036bd70f0832c8a8e17dd610cacc8