### PR TITLE
Update CSP to allow Mailchimp and add newsletter test

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>FAQ - HecCollects</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; connect-src 'self' https://*.api.mailchimp.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="Landing page for HecCollects featuring marketplace links and contact info.">
   <meta name="keywords" content="HecCollects, collectibles, marketplace, eBay, OfferUp, contact">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; connect-src 'self' https://*.api.mailchimp.com; style-src 'self'; font-src 'self' data:">
   <meta property="og:title" content="HecCollects – Landing Page">
   <meta property="og:description" content="Landing page for HecCollects featuring marketplace links and contact info.">
   <meta property="og:url" content="https://heccollects.github.io/">

--- a/privacy.html
+++ b/privacy.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Privacy Policy - HecCollects</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; connect-src 'self' https://*.api.mailchimp.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/returns.html
+++ b/returns.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Shipping & Returns - HecCollects</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' https://www.marchingdogs.com data:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; connect-src 'self' https://*.api.mailchimp.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/sold.html
+++ b/sold.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" href="logo.png">
   <title>Sold Listings - HecCollects</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; style-src 'self'; font-src 'self' data:">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://challenges.cloudflare.com https://www.google.com https://www.gstatic.com; connect-src 'self' https://*.api.mailchimp.com; style-src 'self'; font-src 'self' data:">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="theme.css">
   <script src="env.js"></script>

--- a/tests/newsletter.spec.ts
+++ b/tests/newsletter.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = path.resolve(__dirname, '../index.html');
+
+const mailchimpEndpoint = /https:\/\/.*\.api\.mailchimp\.com\/.*/;
+
+test('newsletter form handles successful Mailchimp response', async ({ page }) => {
+  let requestHandled = false;
+  await page.route(mailchimpEndpoint, async route => {
+    requestHandled = true;
+    const request = route.request();
+    const payload = JSON.parse(request.postData() || '{}');
+    expect(payload.email_address).toBe('tester@example.com');
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' })
+    });
+  });
+
+  await page.addInitScript(() => {
+    window.MAILCHIMP_API_KEY = 'test-key';
+  });
+
+  await page.goto('file://' + filePath);
+  await page.waitForSelector('.subscribe-form');
+
+  const emailInput = page.locator('#subscribe-email');
+  await emailInput.fill('tester@example.com');
+
+  const submitButton = page.locator('.subscribe-form button[type="submit"]');
+  await expect(submitButton).toBeEnabled();
+
+  const message = page.locator('#subscribe-msg');
+
+  await submitButton.click();
+
+  await expect(message).toHaveText('Thanks for subscribing!');
+  expect(requestHandled).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- allow `connect-src 'self' https://*.api.mailchimp.com` in each page CSP so newsletter fetches are permitted
- add a Playwright test that intercepts the Mailchimp request and confirms a successful subscription message

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0494e14ac832c9bedbc541e2ce9f8