### PR TITLE
Refine support navigation

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,7 +1,30 @@
 <footer class="site-footer">
-  <a href="#home" data-analytics="footer-home">Home</a>
-  <a href="sold.html" data-analytics="footer-sold">Sold Listings</a>
-  <a href="faq.html" data-analytics="footer-faq">FAQ</a>
-  <a href="returns.html" data-analytics="footer-returns">Returns</a>
-  <a href="privacy.html" data-analytics="footer-privacy">Privacy Policy</a>
+  <div class="footer-primary-links">
+    <a href="#home" data-analytics="footer-home">Home</a>
+    <a href="sold.html" data-analytics="footer-sold">Sold Listings</a>
+  </div>
+  <nav
+    id="support-resources"
+    class="support-links"
+    aria-labelledby="support-resources-title"
+  >
+    <h2 id="support-resources-title" class="support-links__title">Need help?</h2>
+    <ul class="support-links__list">
+      <li>
+        <a href="faq.html" data-analytics="footer-faq"
+          >Browse our FAQ for quick answers</a
+        >
+      </li>
+      <li>
+        <a href="returns.html" data-analytics="footer-returns"
+          >Understand our Returns process</a
+        >
+      </li>
+      <li>
+        <a href="privacy.html" data-analytics="footer-privacy"
+          >Review our Privacy Policy</a
+        >
+      </li>
+    </ul>
+  </nav>
 </footer>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -11,9 +11,7 @@
     <a href="#subscribe" data-analytics="nav-subscribe">Subscribe</a>
     <a href="#contact" data-analytics="nav-contact">Business Inquiries</a>
     <a href="sold.html" data-analytics="nav-sold">Sold Listings</a>
-    <a href="faq.html" data-analytics="nav-faq">FAQ</a>
-    <a href="returns.html" data-analytics="nav-returns">Returns</a>
-    <a href="privacy.html" data-analytics="nav-privacy">Privacy Policy</a>
+    <a href="#support-resources" data-analytics="nav-support">Support</a>
   </nav>
   <button id="theme-toggle" aria-label="Toggle theme" aria-pressed="false"></button>
   <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-menu">

--- a/style.css
+++ b/style.css
@@ -1289,16 +1289,71 @@ summary:focus {
 .site-footer {
   padding: 1rem calc(env(safe-area-inset-right) + 1rem) 1rem
     calc(env(safe-area-inset-left) + 1rem);
-  text-align: center;
   color: var(--white);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
 }
-  .site-footer a {
-    color: var(--color-primary);
-    margin: 0 0.5rem;
-    text-decoration: none;
-  }
-.site-footer a:hover {
+
+.site-footer a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus-visible {
   text-decoration: underline;
+}
+
+.footer-primary-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.support-links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 32rem;
+}
+
+.support-links__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.support-links__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.support-links__list a {
+  font-weight: 500;
+}
+
+@media (min-width: 768px) {
+  .site-footer {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .support-links {
+    align-items: flex-start;
+  }
 }
 
 .page-nav {


### PR DESCRIPTION
## Summary
- replace the FAQ/Returns/Privacy header links with a single Support entry that points to the footer
- expand the footer with a semantic support navigation grouping for FAQ, Returns, and Privacy Policy
- style the footer support links cluster for accessible spacing and responsive layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0853f60dc832cb5b2ca2f07a3f7c9