### PR TITLE
Refine policy page layouts with hero sections

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -31,37 +31,44 @@
 <body class="faq-page">
   <a class="skip-link" href="#main">Skip to content</a>
   <div data-include="partials/navbar.html"></div>
-  <main id="main" class="policy-content">
-    <h1>Frequently Asked Questions</h1>
-    <nav class="toc" aria-label="Table of contents">
-      <ol>
-        <li><a href="#orders-shipping">Orders &amp; Shipping</a></li>
-        <li><a href="#returns-refunds">Returns &amp; Refunds</a></li>
-        <li><a href="#customer-support">Customer Support</a></li>
-        <li><a href="#payments-pricing">Payments &amp; Pricing</a></li>
-        <li><a href="#product-information">Product Information</a></li>
-      </ol>
-    </nav>
-    <details id="orders-shipping">
-      <summary>Orders & Shipping</summary>
-      <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>
-    </details>
-    <details id="returns-refunds">
-      <summary>Returns & Refunds</summary>
-      <p>Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method once items are received.</p>
-    </details>
-    <details id="customer-support">
-      <summary>Customer Support</summary>
-      <p>I respond to all messages within 24 hours. You have the right to prompt assistance with any order issue.</p>
-    </details>
-    <details id="payments-pricing">
-      <summary>Payments & Pricing</summary>
-      <p>Payments are processed securely, and pricing reflects any applicable taxes or fees. Accepted methods include major credit cards and PayPal.</p>
-    </details>
-    <details id="product-information">
-      <summary>Product Information</summary>
-      <p>All items are described accurately with detailed photos. Contact me for any additional information about condition or provenance.</p>
-    </details>
+  <main id="main" class="policy-page">
+    <header class="policy-hero">
+      <h1>Frequently Asked Questions</h1>
+      <p class="policy-lede">Find quick answers about ordering, shipping, and caring for your HecCollects purchases.</p>
+    </header>
+    <div class="policy-layout">
+      <nav class="policy-toc" aria-label="Table of contents">
+        <ol>
+          <li><a href="#orders-shipping">Orders &amp; Shipping</a></li>
+          <li><a href="#returns-refunds">Returns &amp; Refunds</a></li>
+          <li><a href="#customer-support">Customer Support</a></li>
+          <li><a href="#payments-pricing">Payments &amp; Pricing</a></li>
+          <li><a href="#product-information">Product Information</a></li>
+        </ol>
+      </nav>
+      <section class="policy-accordion">
+        <details id="orders-shipping">
+          <summary>Orders & Shipping</summary>
+          <p>Orders are packed with care and ship within 2 business days. Delivery typically takes 3-5 business days depending on the carrier and destination.</p>
+        </details>
+        <details id="returns-refunds">
+          <summary>Returns & Refunds</summary>
+          <p>Returns are accepted within 30 days of delivery if items are in original condition. Custom or digital items are non-returnable unless defective, and refunds are issued to the original payment method once items are received.</p>
+        </details>
+        <details id="customer-support">
+          <summary>Customer Support</summary>
+          <p>I respond to all messages within 24 hours. You have the right to prompt assistance with any order issue.</p>
+        </details>
+        <details id="payments-pricing">
+          <summary>Payments & Pricing</summary>
+          <p>Payments are processed securely, and pricing reflects any applicable taxes or fees. Accepted methods include major credit cards and PayPal.</p>
+        </details>
+        <details id="product-information">
+          <summary>Product Information</summary>
+          <p>All items are described accurately with detailed photos. Contact me for any additional information about condition or provenance.</p>
+        </details>
+      </section>
+    </div>
   </main>
   <div data-include="partials/footer.html"></div>
   <script type="application/ld+json">

--- a/privacy.html
+++ b/privacy.html
@@ -71,52 +71,59 @@
 <body class="privacy-page">
   <a class="skip-link" href="#main">Skip to content</a>
   <div data-include="partials/navbar.html"></div>
-  <main id="main" class="policy-content">
-    <h1>Privacy Policy</h1>
-    <nav class="toc" aria-label="Table of contents">
-      <ol>
-        <li><a href="#information-we-collect">Information We Collect</a></li>
-        <li><a href="#how-we-use-information">How We Use Information</a></li>
-        <li><a href="#cookie-usage">Cookie Usage</a></li>
-        <li><a href="#analytics-tools">Analytics Tools</a></li>
-        <li><a href="#data-sharing">Data Sharing</a></li>
-        <li><a href="#opt-out-options">Opt-Out Options</a></li>
-        <li><a href="#data-retention">Data Retention</a></li>
-        <li><a href="#your-rights-and-data-requests">Your Rights and Data Requests</a></li>
-      </ol>
-    </nav>
-    <details id="information-we-collect">
-      <summary>Information We Collect</summary>
-      <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>
-    </details>
-    <details id="how-we-use-information">
-      <summary>How We Use Information</summary>
-      <p>Information is used to send updates, respond to inquiries, and enhance site performance. Cookies may be stored on your device to support these functions, and we do not sell or share your information with third parties except as required by law.</p>
-    </details>
-    <details id="cookie-usage">
-      <summary>Cookie Usage</summary>
-      <p>We use essential and analytics cookies to remember your preferences and understand site traffic. You can control cookies through your browser settings.</p>
-    </details>
-    <details id="analytics-tools">
-      <summary>Analytics Tools</summary>
-      <p>We use privacy-focused analytics tools to measure visits and performance. These tools collect aggregated data and store it for up to 24 months.</p>
-    </details>
-    <details id="data-sharing">
-      <summary>Data Sharing</summary>
-      <p>Personal information is not sold. Data may be shared with service providers that help operate the site or as required by law.</p>
-    </details>
-    <details id="opt-out-options">
-      <summary>Opt-Out Options</summary>
-      <p>You can opt out of analytics by blocking cookies or using browser extensions. To stop receiving emails or remove your information, use unsubscribe links or contact us.</p>
-    </details>
-    <details id="data-retention">
-      <summary>Data Retention</summary>
-      <p>Mailing list data is kept until you unsubscribe or request deletion. Aggregated analytics data is retained for up to 24 months to help improve the site.</p>
-    </details>
-    <details id="your-rights-and-data-requests">
-      <summary>Your Rights and Data Requests</summary>
-      <p>You have the right to access, correct, or erase your personal information. For data requests or questions, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
-    </details>
+  <main id="main" class="policy-page">
+    <header class="policy-hero">
+      <h1>Privacy Policy</h1>
+      <p class="policy-lede">Learn how your personal information is collected, used, and protected when you interact with HecCollects.</p>
+    </header>
+    <div class="policy-layout">
+      <nav class="policy-toc" aria-label="Table of contents">
+        <ol>
+          <li><a href="#information-we-collect">Information We Collect</a></li>
+          <li><a href="#how-we-use-information">How We Use Information</a></li>
+          <li><a href="#cookie-usage">Cookie Usage</a></li>
+          <li><a href="#analytics-tools">Analytics Tools</a></li>
+          <li><a href="#data-sharing">Data Sharing</a></li>
+          <li><a href="#opt-out-options">Opt-Out Options</a></li>
+          <li><a href="#data-retention">Data Retention</a></li>
+          <li><a href="#your-rights-and-data-requests">Your Rights and Data Requests</a></li>
+        </ol>
+      </nav>
+      <section class="policy-accordion">
+        <details id="information-we-collect">
+          <summary>Information We Collect</summary>
+          <p>We collect details you provide when joining our mailing list or contacting us. Analytics tools also gather general usage data to improve the site.</p>
+        </details>
+        <details id="how-we-use-information">
+          <summary>How We Use Information</summary>
+          <p>Information is used to send updates, respond to inquiries, and enhance site performance. Cookies may be stored on your device to support these functions, and we do not sell or share your information with third parties except as required by law.</p>
+        </details>
+        <details id="cookie-usage">
+          <summary>Cookie Usage</summary>
+          <p>We use essential and analytics cookies to remember your preferences and understand site traffic. You can control cookies through your browser settings.</p>
+        </details>
+        <details id="analytics-tools">
+          <summary>Analytics Tools</summary>
+          <p>We use privacy-focused analytics tools to measure visits and performance. These tools collect aggregated data and store it for up to 24 months.</p>
+        </details>
+        <details id="data-sharing">
+          <summary>Data Sharing</summary>
+          <p>Personal information is not sold. Data may be shared with service providers that help operate the site or as required by law.</p>
+        </details>
+        <details id="opt-out-options">
+          <summary>Opt-Out Options</summary>
+          <p>You can opt out of analytics by blocking cookies or using browser extensions. To stop receiving emails or remove your information, use unsubscribe links or contact us.</p>
+        </details>
+        <details id="data-retention">
+          <summary>Data Retention</summary>
+          <p>Mailing list data is kept until you unsubscribe or request deletion. Aggregated analytics data is retained for up to 24 months to help improve the site.</p>
+        </details>
+        <details id="your-rights-and-data-requests">
+          <summary>Your Rights and Data Requests</summary>
+          <p>You have the right to access, correct, or erase your personal information. For data requests or questions, contact <a href="mailto:hectorsandoval1402@gmail.com">hectorsandoval1402@gmail.com</a>.</p>
+        </details>
+      </section>
+    </div>
   </main>
   <div data-include="partials/footer.html"></div>
   <button id="back-to-top" class="back-to-top" aria-label="Back to top">↑</button>

--- a/returns.html
+++ b/returns.html
@@ -31,45 +31,52 @@
 <body class="returns-page">
   <a class="skip-link" href="#main">Skip to content</a>
   <div data-include="partials/navbar.html"></div>
-  <main id="main" class="policy-content">
-    <h1>Shipping &amp; Returns</h1>
-    <nav class="toc" aria-label="Table of contents">
-      <ol>
-        <li><a href="#shipping-policy">Shipping Policy</a></li>
-        <li><a href="#returns-policy">Returns Policy</a></li>
-        <li><a href="#refund-exceptions">Refund Exceptions</a></li>
-        <li><a href="#customer-rights">Customer Rights</a></li>
-        <li><a href="#communication-expectations">Communication Expectations</a></li>
-      </ol>
-    </nav>
-    <details id="shipping-policy">
-      <summary>Shipping Policy</summary>
-      <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>
-      <p>For common questions about delivery, see the <a href="faq.html#orders-shipping">Orders &amp; Shipping FAQ</a>.</p>
-    </details>
-    <details id="returns-policy">
-      <summary>Returns Policy</summary>
-      <p>Returns are accepted within 30 days of delivery. Items must be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
-      <h2 id="initiating-a-return">Initiating a Return</h2>
-      <p>To start a return, reach out via the <a href="index.html#contact">contact form</a> with your order details. I will provide instructions within 24 hours.</p>
-      <h2 id="packaging-expectations">Packaging Expectations</h2>
-      <p>Securely repackage items to prevent damage in transit and include all original accessories or documentation.</p>
-      <h2 id="refund-timeline">Refund Timeline</h2>
-      <p>Refunds are issued to the original payment method within 2 business days after the item is received and inspected.</p>
-      <p>Additional details are available in the <a href="faq.html#returns-refunds">Returns &amp; Refunds FAQ</a>.</p>
-    </details>
-    <details id="refund-exceptions">
-      <summary>Refund Exceptions</summary>
-      <p>Custom or personalized orders and digital items are non-refundable unless defective. Shipping costs are non-refundable once an order has shipped.</p>
-    </details>
-    <details id="customer-rights">
-      <summary>Customer Rights</summary>
-      <p>You may request an exchange or refund for eligible items. If a dispute arises, you have the right to seek resolution through your payment provider or applicable consumer protection laws.</p>
-    </details>
-    <details id="communication-expectations">
-      <summary>Communication Expectations</summary>
-      <p>I strive to answer all messages within 24 hours. Reach out with any order questions and I'll work to make things right.</p>
-    </details>
+  <main id="main" class="policy-page">
+    <header class="policy-hero">
+      <h1>Shipping &amp; Returns</h1>
+      <p class="policy-lede">Understand how shipping, returns, and refunds work so you can shop with confidence.</p>
+    </header>
+    <div class="policy-layout">
+      <nav class="policy-toc" aria-label="Table of contents">
+        <ol>
+          <li><a href="#shipping-policy">Shipping Policy</a></li>
+          <li><a href="#returns-policy">Returns Policy</a></li>
+          <li><a href="#refund-exceptions">Refund Exceptions</a></li>
+          <li><a href="#customer-rights">Customer Rights</a></li>
+          <li><a href="#communication-expectations">Communication Expectations</a></li>
+        </ol>
+      </nav>
+      <section class="policy-accordion">
+        <details id="shipping-policy">
+          <summary>Shipping Policy</summary>
+          <p>Orders ship within 2 business days via trusted carriers. Tracking information is provided as soon as it's available, and delivery times may vary by destination.</p>
+          <p>For common questions about delivery, see the <a href="faq.html#orders-shipping">Orders &amp; Shipping FAQ</a>.</p>
+        </details>
+        <details id="returns-policy">
+          <summary>Returns Policy</summary>
+          <p>Returns are accepted within 30 days of delivery. Items must be in original condition. Buyers pay return shipping unless the item arrived damaged or incorrect.</p>
+          <h3 id="initiating-a-return">Initiating a Return</h3>
+          <p>To start a return, reach out via the <a href="index.html#contact">contact form</a> with your order details. I will provide instructions within 24 hours.</p>
+          <h3 id="packaging-expectations">Packaging Expectations</h3>
+          <p>Securely repackage items to prevent damage in transit and include all original accessories or documentation.</p>
+          <h3 id="refund-timeline">Refund Timeline</h3>
+          <p>Refunds are issued to the original payment method within 2 business days after the item is received and inspected.</p>
+          <p>Additional details are available in the <a href="faq.html#returns-refunds">Returns &amp; Refunds FAQ</a>.</p>
+        </details>
+        <details id="refund-exceptions">
+          <summary>Refund Exceptions</summary>
+          <p>Custom or personalized orders and digital items are non-refundable unless defective. Shipping costs are non-refundable once an order has shipped.</p>
+        </details>
+        <details id="customer-rights">
+          <summary>Customer Rights</summary>
+          <p>You may request an exchange or refund for eligible items. If a dispute arises, you have the right to seek resolution through your payment provider or applicable consumer protection laws.</p>
+        </details>
+        <details id="communication-expectations">
+          <summary>Communication Expectations</summary>
+          <p>I strive to answer all messages within 24 hours. Reach out with any order questions and I'll work to make things right.</p>
+        </details>
+      </section>
+    </div>
   </main>
   <div data-include="partials/footer.html"></div>
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- refactor the FAQ, Shipping & Returns, and Privacy pages to use the new policy layout structure
- add consistent hero headings and lead descriptions for each policy page
- adjust the Shipping & Returns subsections to keep the heading hierarchy accessible

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d08e0185fc832caea711b1b046a74a