### PR TITLE
Refine policy page surfaces and layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -255,58 +255,222 @@ noscript p {
   background: var(--color-primary);
   color: var(--white);
 }
-details {
-  margin: 1rem 0;
-  padding: 1rem;
-  border: 2px solid rgba(var(--white-rgb), 0.18);
-  border-radius: 1rem;
-  background: rgba(var(--white-rgb), 0.08);
-  scroll-margin-top: var(--navbar-height);
+/* ---------- Policy pages ---------- */
+.policy-page {
+  width: min(100%, 1100px);
+  margin: 0 auto;
+  padding: calc(var(--navbar-height) + 2rem) clamp(1.5rem, 4vw, 3rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 4vw, 3rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 2rem;
+  box-shadow: 0 32px 60px rgba(var(--black-rgb), 0.35);
+  color: var(--color-text);
 }
-summary {
-  cursor: pointer;
-  font-size: var(--font-size-h3);
-  font-weight: 600;
-  line-height: var(--line-height-heading);
-  color: var(--color-primary);
-  list-style: none;
-}
-summary::-webkit-details-marker {
-  display: none;
-}
-summary:focus {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 0.2rem;
-}
-/* ---------- Table of Contents ---------- */
-.toc {
-  margin: 1rem 0;
-  padding: 1rem;
-  border: 2px solid rgba(var(--white-rgb), 0.18);
-  border-radius: 1rem;
-  background: rgba(var(--white-rgb), 0.05);
+
+.policy-hero {
+  padding: clamp(1.75rem, 4vw, 3.25rem);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-outline-strong);
+  border-radius: 1.75rem;
+  box-shadow: 0 28px 56px rgba(var(--black-rgb), 0.3);
   text-align: left;
-  font-size: 0.95rem;
+  display: grid;
+  gap: 0.75rem;
 }
+
+.policy-hero h1 {
+  font-size: clamp(2.125rem, 4vw, 2.75rem);
+  line-height: 1.2;
+}
+
+.policy-hero .policy-lede {
+  font-size: clamp(1.05rem, 1.1vw + 1rem, 1.25rem);
+  line-height: 1.7;
+  color: var(--color-muted);
+  max-width: 60ch;
+}
+
+.policy-layout {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.policy-toc,
+.toc {
+  position: relative;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-outline-strong);
+  background: var(--color-surface-raised);
+  box-shadow: 0 20px 48px rgba(var(--black-rgb), 0.28);
+  text-align: left;
+  font-size: 0.98rem;
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  scroll-margin-top: var(--navbar-height);
+  align-self: start;
+}
+
+.policy-toc::before,
+.toc::before {
+  content: "On this page";
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  color: var(--color-muted);
+}
+
+.policy-toc > ol,
 .toc > ol {
   list-style: none;
   padding-left: 0;
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.policy-toc li,
+.toc li {
+  border-left: 2px solid rgba(var(--color-muted-rgb), 0.4);
+  padding-left: 0.85rem;
+}
+
+.policy-toc a,
+.toc a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.policy-toc a:hover,
+.policy-toc a:focus-visible,
+.toc a:hover,
+.toc a:focus-visible {
+  color: var(--color-secondary);
+  text-decoration: underline;
+}
+
+.policy-accordion {
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.policy-accordion details {
+  position: relative;
+  padding: clamp(1.5rem, 2.5vw, 2rem);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-raised);
+  box-shadow: 0 24px 56px rgba(var(--black-rgb), 0.32);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease,
+    transform 0.25s ease;
+  scroll-margin-top: var(--navbar-height);
+}
+
+.policy-accordion details:hover {
+  border-color: var(--color-outline-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 32px 70px rgba(var(--black-rgb), 0.36);
+}
+
+.policy-accordion details[open] {
+  border-color: var(--color-primary);
+  box-shadow: 0 36px 80px rgba(var(--black-rgb), 0.38);
+}
+
+.policy-accordion summary {
+  cursor: pointer;
+  font-size: clamp(1.2rem, 1.5vw + 1rem, 1.5rem);
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--color-text);
+  list-style: none;
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 1rem;
+  padding-right: 2.5rem;
+  transition: color 0.2s ease;
 }
-.toc ol ol {
-  padding-left: 1rem;
+
+.policy-accordion summary::-webkit-details-marker {
+  display: none;
 }
-  .toc a {
-    text-decoration: none;
-    color: var(--color-primary);
-    font-weight: 600;
+
+.policy-accordion summary::after {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  margin-left: auto;
+  border-right: 3px solid currentColor;
+  border-bottom: 3px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 0.3s ease;
+  flex-shrink: 0;
+}
+
+.policy-accordion details[open] > summary::after {
+  transform: rotate(45deg);
+}
+
+.policy-accordion summary:hover {
+  color: var(--color-primary);
+}
+
+.policy-accordion summary:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 0.35rem;
+}
+
+.policy-accordion details > *:not(summary) {
+  margin-top: 1rem;
+}
+
+.policy-accordion p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--color-text);
+}
+
+.policy-accordion h3 {
+  font-size: clamp(1.05rem, 0.5vw + 1rem, 1.25rem);
+  margin-top: 1rem;
+}
+
+@media (min-width: 960px) {
+  .policy-layout {
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+    align-items: start;
   }
-@media (min-width: 768px) {
-  .toc > ol {
-    flex-direction: row;
-    flex-wrap: wrap;
+
+  .policy-toc,
+  .toc {
+    position: sticky;
+    top: calc(var(--navbar-height) + 1.5rem);
+  }
+}
+
+@media (max-width: 599px) {
+  .policy-page {
+    padding: calc(var(--navbar-height) + 1.5rem) 1rem 2rem;
+  }
+
+  .policy-hero {
+    border-radius: 1.25rem;
+  }
+
+  .policy-accordion details {
+    border-radius: 1.25rem;
   }
 }
 /* ---------- Buttons ---------- */

--- a/theme.css
+++ b/theme.css
@@ -4,10 +4,14 @@
   --color-bg-rgb: 250, 250, 250;
   --color-surface: #e5e5e5;
   --color-surface-rgb: 229, 229, 229;
+  --color-surface-raised: #fdfdfd;
+  --color-surface-raised-rgb: 253, 253, 253;
   --color-text: #222222;
   --color-text-rgb: 34, 34, 34;
   --color-muted: #888888;
   --color-muted-rgb: 136, 136, 136;
+  --color-outline: rgba(34, 34, 34, 0.12);
+  --color-outline-strong: rgba(34, 34, 34, 0.18);
 
   /* 30% brand colors */
   --brand-primary: #2563eb;
@@ -46,10 +50,14 @@
   --color-bg-rgb: 10, 10, 10;
   --color-surface: #1a1a1a;
   --color-surface-rgb: 26, 26, 26;
+  --color-surface-raised: #141414;
+  --color-surface-raised-rgb: 20, 20, 20;
   --color-text: #f5f5f5;
   --color-text-rgb: 245, 245, 245;
   --color-muted: #a3a3a3;
   --color-muted-rgb: 163, 163, 163;
+  --color-outline: rgba(245, 245, 245, 0.16);
+  --color-outline-strong: rgba(245, 245, 245, 0.28);
 
   --brand-primary: #3b82f6;
   --brand-primary-rgb: 59, 130, 246;
@@ -71,10 +79,14 @@
   --color-bg-rgb: 0, 0, 0;
   --color-surface: #000;
   --color-surface-rgb: 0, 0, 0;
+  --color-surface-raised: #000;
+  --color-surface-raised-rgb: 0, 0, 0;
   --color-text: #fff;
   --color-text-rgb: 255, 255, 255;
   --color-muted: #fff;
   --color-muted-rgb: 255, 255, 255;
+  --color-outline: #fff;
+  --color-outline-strong: #fff;
 }
 
 body {


### PR DESCRIPTION
## Summary
- restyle policy page containers, heroes, table of contents, and accordion entries with solid surfaces, stronger elevation, and a responsive two-column grid
- scope accordion details/summary styling with custom toggle indicators, improved typography, and hover/focus treatments
- add design tokens for raised surfaces and outlines across themes to keep contrast consistent in light, dark, and high-contrast modes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d09ac83644832ca185520460ba14e6