### PR TITLE
Refresh navbar layout for slimmer header

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,10 @@ Playwright Test will execute the browser-based tests.
 
 ## Navbar Variants
 
-The floating navbar layout is enabled by default through the `navbar--floating` class added to the shared header partial.
-To preview the classic bar instead, set `data-nav-variant="classic"` on either `<html>` or `<body>` (the include script will remove the floating class) or drop the modifier class from the rendered markup.
-You can also force the floating variant without editing the partial by setting `data-nav-variant="floating"` before includes hydrate:
-
-```js
-document.documentElement.setAttribute('data-nav-variant', 'floating');
-```
-
-The Playwright specs follow this pattern so reviewers can toggle between layouts from the browser console without editing templates.
+The header now renders in the classic flat style by default.
+If you need to re-introduce the legacy floating modifier for experiments or downstream builds, set `data-nav-variant="floating"` on either `<html>` or `<body>` before the includes hydrate.
+The loader will attach the `navbar--floating` class so custom CSS can hook into it, but the project no longer ships floating-specific styles out of the box.
+The Playwright specs still follow this pattern so reviewers can toggle classes from the browser console without editing templates.
 
 ## Data Fetch Scripts
 

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,11 +1,9 @@
-<header class="navbar navbar--floating" role="banner">
+<header class="navbar" role="banner">
   <div class="navbar__surface">
     <a href="#home" class="brand" data-analytics="nav-home">
       <img src="logo.svg" alt="HecCollects logo" width="44" height="44">
-      <span class="brand-text">
-        <span class="brand-title">HecCollects</span>
-        <span class="brand-tagline">Collectibles · Community · Care</span>
-      </span>
+      <span class="brand-title">HecCollects</span>
+      <span class="sr-only">Collectibles · Community · Care</span>
     </a>
     <nav id="nav-menu" class="nav-menu" aria-label="Primary">
       <ul class="nav-links" role="list">

--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -1,14 +1,12 @@
 (() => {
   const isHome = location.pathname === '/' || location.pathname.endsWith('/index.html');
   const templates = {
-    'partials/navbar.html': `<header class="navbar navbar--floating" role="banner">
+    'partials/navbar.html': `<header class="navbar" role="banner">
   <div class="navbar__surface">
     <a href="#home" class="brand" data-analytics="nav-home">
       <img src="logo.svg" alt="HecCollects logo" width="44" height="44">
-      <span class="brand-text">
-        <span class="brand-title">HecCollects</span>
-        <span class="brand-tagline">Collectibles · Community · Care</span>
-      </span>
+      <span class="brand-title">HecCollects</span>
+      <span class="sr-only">Collectibles · Community · Care</span>
     </a>
     <nav id="nav-menu" class="nav-menu" aria-label="Primary">
       <ul class="nav-links" role="list">
@@ -93,12 +91,8 @@
       document.body?.dataset.navVariant ||
       document.documentElement.dataset.navVariant;
     const navbar = document.querySelector('.navbar');
-    if (navbar) {
-      if (navVariantAttr === 'classic') {
-        navbar.classList.remove('navbar--floating');
-      } else if (navVariantAttr === 'floating') {
-        navbar.classList.add('navbar--floating');
-      }
+    if (navbar && navVariantAttr === 'floating') {
+      navbar.classList.add('navbar--floating');
     }
 
     if (!isHome) {

--- a/style.css
+++ b/style.css
@@ -988,65 +988,35 @@ noscript p {
   top: 0;
   left: 0;
   width: 100%;
-  padding: calc(env(safe-area-inset-top)+0.7rem)
-    calc(env(safe-area-inset-right)+1.5rem) 0.7rem
-    calc(env(safe-area-inset-left)+1.5rem);
+  padding: calc(env(safe-area-inset-top) + 0.25rem)
+    clamp(1.25rem, 4vw, 2.5rem) 0
+    clamp(1.25rem, 4vw, 2.5rem);
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 4vw, 2.5rem);
-  background: linear-gradient(
-      120deg,
-      rgba(var(--white-rgb), 0.92),
-      rgba(var(--white-rgb), 0.88)
-    )
-    border-box;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  justify-content: center;
+  background: var(--color-surface-raised);
+  border-bottom: 1px solid var(--color-outline);
   z-index: 10000;
-  box-shadow: 0 18px 40px rgba(var(--black-rgb), 0.12);
-  border-bottom: 1px solid rgba(var(--black-rgb), 0.05);
 }
 
 .navbar__surface {
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 4vw, 2.5rem);
-  width: 100%;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  width: min(100%, 1100px);
+  margin: 0 auto;
+  padding: 0.65rem clamp(1.25rem, 3vw, 2rem);
 }
 
 .navbar__surface .nav-toggle {
   margin-left: auto;
 }
 
-.navbar--floating,
-[data-nav-variant="floating"] .navbar {
-  justify-content: center;
-  padding: calc(env(safe-area-inset-top) + 1rem)
-    clamp(1.25rem, 4vw, 3rem) 1rem
-    clamp(1.25rem, 4vw, 3rem);
-  background: transparent;
-  box-shadow: none;
-  border-bottom: none;
-}
-
-.navbar--floating .navbar__surface,
-[data-nav-variant="floating"] .navbar__surface {
-  width: min(100%, 1100px);
-  background: rgba(var(--white-rgb), 0.92);
-  border-radius: 999px;
-  padding: 0.65rem clamp(1rem, 3vw, 1.75rem);
-  box-shadow: 0 24px 48px rgba(var(--black-rgb), 0.14);
-  border: 1px solid rgba(var(--black-rgb), 0.05);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  gap: clamp(1rem, 3vw, 2rem);
-}
-
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  font-size: 1.25rem;
+  gap: 0.65rem;
+  font-size: 1.15rem;
   font-weight: 700;
   text-decoration: none;
   color: inherit;
@@ -1057,20 +1027,9 @@ noscript p {
 .brand:focus-visible {
   transform: translateY(-1px);
 }
-.brand-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-}
 .brand-title {
   font-size: 1.05rem;
-  letter-spacing: 0.03em;
-}
-.brand-tagline {
-  font-size: 0.7rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(var(--black-rgb), 0.55);
+  letter-spacing: 0.04em;
 }
 .nav-toggle {
   width: 32px;
@@ -1113,10 +1072,6 @@ noscript p {
   transform: translateY(-1px);
   box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb), 0.25);
 }
-.navbar--floating #theme-toggle,
-[data-nav-variant="floating"] .navbar #theme-toggle {
-  margin-left: clamp(0.5rem, 3vw, 1.25rem);
-}
 .nav-toggle.open .line:nth-child(1) {
   transform: translateY(9px) rotate(45deg);
 }
@@ -1130,7 +1085,7 @@ noscript p {
 .nav-menu {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
   padding: 1.5rem;
   align-items: stretch;
   flex: 1 1 auto;
@@ -1298,8 +1253,8 @@ noscript p {
 }
 @media (min-width: 768px) {
   .nav-menu {
-    gap: 2.5rem;
-    padding: 2rem;
+    gap: 2rem;
+    padding: 1.75rem;
   }
   .nav-links {
     gap: 1.5rem;
@@ -1315,23 +1270,15 @@ noscript p {
 }
 @media (min-width: 1024px) {
   .navbar {
-    justify-content: space-between;
     padding-right: clamp(2rem, 5vw, 4rem);
     padding-left: clamp(2rem, 5vw, 4rem);
   }
-  .navbar--floating,
-  [data-nav-variant="floating"] .navbar {
-    padding: calc(env(safe-area-inset-top) + 1.25rem)
-      clamp(1.75rem, 4vw, 3.5rem) 1.25rem
-      clamp(1.75rem, 4vw, 3.5rem);
-  }
-  .navbar--floating .navbar__surface,
-  [data-nav-variant="floating"] .navbar__surface {
+  .navbar__surface {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    column-gap: clamp(1.5rem, 3vw, 2.5rem);
-    padding: 0.85rem clamp(1.5rem, 3vw, 2.5rem);
+    column-gap: clamp(1.25rem, 3vw, 2rem);
+    padding: 0.65rem clamp(1.75rem, 3vw, 2.5rem);
   }
   .nav-toggle {
     display: none;
@@ -1339,18 +1286,10 @@ noscript p {
   .nav-menu {
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
-    gap: clamp(2rem, 4vw, 3.5rem);
+    gap: clamp(1.25rem, 2vw, 1.75rem);
     background: none;
     padding: 0;
-  }
-  .navbar--floating .nav-menu,
-  [data-nav-variant="floating"] .navbar .nav-menu {
     flex: 1;
-    display: flex;
-    align-items: center;
-    gap: clamp(1.75rem, 3vw, 3rem);
-    justify-content: center;
   }
   .nav-menu.nav-menu-ready {
     position: static;
@@ -1364,22 +1303,14 @@ noscript p {
   }
   .nav-links {
     flex-direction: row;
-    gap: clamp(1.5rem, 2vw, 2.5rem);
-  }
-  .navbar--floating .nav-links,
-  [data-nav-variant="floating"] .navbar .nav-links {
-    flex: 1;
-    justify-content: center;
+    align-items: center;
+    gap: clamp(1.25rem, 2vw, 1.75rem);
   }
   .nav-actions {
     flex-direction: row;
-    gap: 1rem;
-  }
-  .navbar--floating .nav-actions,
-  [data-nav-variant="floating"] .navbar .nav-actions {
+    align-items: center;
+    gap: clamp(1rem, 2vw, 1.5rem);
     margin-left: auto;
-    justify-content: flex-end;
-    gap: clamp(0.75rem, 2vw, 1.5rem);
   }
   .dropdown-menu {
     position: absolute;
@@ -1397,8 +1328,7 @@ noscript p {
   .nav-item {
     position: relative;
   }
-  .navbar--floating #theme-toggle,
-  [data-nav-variant="floating"] .navbar #theme-toggle {
+  #theme-toggle {
     justify-self: end;
     margin-left: clamp(1rem, 2vw, 1.5rem);
   }

--- a/theme.css
+++ b/theme.css
@@ -149,31 +149,7 @@ body.js-has-transition.fade-out::after {
 
 [data-theme="dark"] .navbar,
 [data-theme="hc"] .navbar {
-  background: rgba(var(--black-rgb), 0.45);
-}
-
-[data-theme="dark"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar),
-[data-theme="hc"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) {
-  background: transparent;
-}
-
-[data-theme="dark"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) .navbar__surface {
-  background: rgba(var(--color-surface-rgb), 0.22);
-  border-color: rgba(var(--color-text-rgb), 0.18);
-  box-shadow: 0 28px 54px rgba(var(--black-rgb), 0.45);
-}
-
-[data-theme="hc"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) .navbar__surface {
-  background: rgba(var(--color-surface-rgb), 0.35);
-  border-color: rgba(var(--color-text-rgb), 0.32);
-  box-shadow: 0 32px 64px rgba(var(--black-rgb), 0.55);
-}
-
-[data-theme="dark"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) .nav-menu a:focus-visible::after,
-[data-theme="hc"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) .nav-menu a:focus-visible::after,
-[data-theme="dark"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) .dropdown-toggle:focus-visible::after,
-[data-theme="hc"] :is(.navbar--floating, [data-nav-variant="floating"] .navbar) .dropdown-toggle:focus-visible::after {
-  background: rgba(var(--color-text-rgb), 0.6);
+  background: var(--color-surface);
 }
 
 [data-theme="dark"] .policy-page,
@@ -203,11 +179,6 @@ body.js-has-transition.fade-out::after {
 [data-theme="dark"] .nav-link-ghost,
 [data-theme="hc"] .nav-link-ghost {
   color: var(--color-text);
-}
-
-[data-theme="dark"] .brand-tagline,
-[data-theme="hc"] .brand-tagline {
-  color: rgba(var(--color-text-rgb), 0.7);
 }
 
 [data-theme="dark"] .nav-link-ghost,


### PR DESCRIPTION
## Summary
- simplify the shared navbar markup and default include to drop the floating modifier and keep the brand on a single line
- restyle the navbar with a flat surface, tighter padding, and refined desktop spacing while updating theme overrides
- document the classic default and leave the floating hook as an optional legacy modifier

## Testing
- npx http-server -p 4173

------
https://chatgpt.com/codex/tasks/task_e_68e2ad3263a0832c9cc058230cdcb63d