### PR TITLE
Restore floating navbar variant and adjust layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Playwright Test will execute the browser-based tests.
 
 ## Navbar Variants
 
-The compact navbar layout is enabled by default through the `navbar--compact` class added to the shared header partial.
-To preview the classic bar instead, set `data-nav-variant="classic"` on either `<html>` or `<body>` (the include script will remove the compact class) or drop the modifier class from the rendered markup.
-You can also force the compact variant without editing the partial by setting `data-nav-variant="compact"` before includes hydrate:
+The floating navbar layout is restored as the default via the `navbar--floating` class that ships with the shared header partial.
+To force the compact layout without editing the markup, set `data-nav-variant="compact"` on either `<html>` or `<body>` before the includes script hydrates the partial:
 
 ```js
 document.documentElement.setAttribute('data-nav-variant', 'compact');
 ```
 
+Setting `data-nav-variant="floating"` (or the legacy `classic`) re-applies the floating modifier if a page needs to override a previously stored preference.
 The Playwright specs follow this pattern so reviewers can toggle between layouts from the browser console without editing templates.
 
 ## Data Fetch Scripts

--- a/faq.html
+++ b/faq.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image" content="logo.png">
   <link rel="canonical" href="https://heccollects.github.io/faq.html">
 </head>
-<body class="faq-page">
+<body class="faq-page" data-nav-variant="compact">
   <a class="skip-link" href="#main">Skip to content</a>
   <div data-include="partials/navbar.html"></div>
   <main id="main" class="policy-page">

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,4 +1,4 @@
-<header class="navbar navbar--compact" role="banner">
+<header class="navbar navbar--floating" role="banner">
   <div class="navbar__surface">
     <a href="#home" class="brand" data-analytics="nav-home">
       <img src="logo.svg" alt="HecCollects logo" width="44" height="44">
@@ -12,22 +12,22 @@
         <li class="nav-item"><a href="#testimonials" data-analytics="nav-reviews" data-nav-link>Customer Reviews</a></li>
         <li class="nav-item"><a href="#story" data-analytics="nav-story" data-nav-link>Our Story</a></li>
         <li class="nav-item"><a href="#approach" data-analytics="nav-approach" data-nav-link>Built on Trust</a></li>
-      <li class="nav-item"><a href="#ebay" data-analytics="nav-ebay" data-nav-link>eBay</a></li>
-      <li class="nav-item"><a href="#offerup" data-analytics="nav-offerup" data-nav-link>OfferUp</a></li>
-      <li class="nav-item"><a href="#subscribe" data-analytics="nav-subscribe" data-nav-link>Subscribe</a></li>
-      <li class="nav-item"><a href="#support-resources" data-analytics="nav-support" data-nav-link>Support</a></li>
-      <li class="nav-item has-dropdown">
-        <button class="dropdown-toggle" type="button" aria-expanded="false" aria-controls="resources-menu">
-          Resources
-          <span class="dropdown-icon" aria-hidden="true"></span>
-        </button>
-        <ul id="resources-menu" class="dropdown-menu" role="menu" hidden>
-          <li role="none"><a role="menuitem" href="faq.html" data-analytics="nav-faq">FAQ</a></li>
-          <li role="none"><a role="menuitem" href="returns.html" data-analytics="nav-returns">Returns</a></li>
-          <li role="none"><a role="menuitem" href="privacy.html" data-analytics="nav-privacy">Privacy</a></li>
-        </ul>
-      </li>
-    </ul>
+        <li class="nav-item"><a href="#ebay" data-analytics="nav-ebay" data-nav-link>eBay</a></li>
+        <li class="nav-item"><a href="#offerup" data-analytics="nav-offerup" data-nav-link>OfferUp</a></li>
+        <li class="nav-item"><a href="#subscribe" data-analytics="nav-subscribe" data-nav-link>Subscribe</a></li>
+        <li class="nav-item"><a href="#support-resources" data-analytics="nav-support" data-nav-link>Support</a></li>
+        <li class="nav-item has-dropdown">
+          <button class="dropdown-toggle" type="button" aria-expanded="false" aria-controls="resources-menu">
+            Resources
+            <span class="dropdown-icon" aria-hidden="true"></span>
+          </button>
+          <ul id="resources-menu" class="dropdown-menu" role="menu" hidden>
+            <li role="none"><a role="menuitem" href="faq.html" data-analytics="nav-faq">FAQ</a></li>
+            <li role="none"><a role="menuitem" href="returns.html" data-analytics="nav-returns">Returns</a></li>
+            <li role="none"><a role="menuitem" href="privacy.html" data-analytics="nav-privacy">Privacy</a></li>
+          </ul>
+        </li>
+      </ul>
       <div class="nav-actions">
         <a class="btn nav-cta" href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" data-analytics="nav-shop">Shop eBay</a>
         <a class="nav-link-ghost" href="#contact" data-analytics="nav-contact" data-nav-link>Contact</a>

--- a/privacy.html
+++ b/privacy.html
@@ -68,7 +68,7 @@
       }
     </script>
 </head>
-<body class="privacy-page">
+<body class="privacy-page" data-nav-variant="compact">
   <a class="skip-link" href="#main">Skip to content</a>
   <div data-include="partials/navbar.html"></div>
   <main id="main" class="policy-page">

--- a/returns.html
+++ b/returns.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image" content="logo.png">
   <link rel="canonical" href="https://heccollects.github.io/returns.html">
 </head>
-<body class="returns-page">
+<body class="returns-page" data-nav-variant="compact">
   <a class="skip-link" href="#main">Skip to content</a>
   <div data-include="partials/navbar.html"></div>
   <main id="main" class="policy-page">

--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -1,7 +1,7 @@
 (() => {
   const isHome = location.pathname === '/' || location.pathname.endsWith('/index.html');
   const templates = {
-    'partials/navbar.html': `<header class="navbar navbar--compact" role="banner">
+    'partials/navbar.html': `<header class="navbar navbar--floating" role="banner">
   <div class="navbar__surface">
     <a href="#home" class="brand" data-analytics="nav-home">
       <img src="logo.svg" alt="HecCollects logo" width="44" height="44">
@@ -15,22 +15,22 @@
         <li class="nav-item"><a href="#testimonials" data-analytics="nav-reviews" data-nav-link>Customer Reviews</a></li>
         <li class="nav-item"><a href="#story" data-analytics="nav-story" data-nav-link>Our Story</a></li>
         <li class="nav-item"><a href="#approach" data-analytics="nav-approach" data-nav-link>Built on Trust</a></li>
-      <li class="nav-item"><a href="#ebay" data-analytics="nav-ebay" data-nav-link>eBay</a></li>
-      <li class="nav-item"><a href="#offerup" data-analytics="nav-offerup" data-nav-link>OfferUp</a></li>
-      <li class="nav-item"><a href="#subscribe" data-analytics="nav-subscribe" data-nav-link>Subscribe</a></li>
-      <li class="nav-item"><a href="#support-resources" data-analytics="nav-support" data-nav-link>Support</a></li>
-      <li class="nav-item has-dropdown">
-        <button class="dropdown-toggle" type="button" aria-expanded="false" aria-controls="resources-menu">
-          Resources
-          <span class="dropdown-icon" aria-hidden="true"></span>
-        </button>
-        <ul id="resources-menu" class="dropdown-menu" role="menu" hidden>
-          <li role="none"><a role="menuitem" href="faq.html" data-analytics="nav-faq">FAQ</a></li>
-          <li role="none"><a role="menuitem" href="returns.html" data-analytics="nav-returns">Returns</a></li>
-          <li role="none"><a role="menuitem" href="privacy.html" data-analytics="nav-privacy">Privacy</a></li>
-        </ul>
-      </li>
-    </ul>
+        <li class="nav-item"><a href="#ebay" data-analytics="nav-ebay" data-nav-link>eBay</a></li>
+        <li class="nav-item"><a href="#offerup" data-analytics="nav-offerup" data-nav-link>OfferUp</a></li>
+        <li class="nav-item"><a href="#subscribe" data-analytics="nav-subscribe" data-nav-link>Subscribe</a></li>
+        <li class="nav-item"><a href="#support-resources" data-analytics="nav-support" data-nav-link>Support</a></li>
+        <li class="nav-item has-dropdown">
+          <button class="dropdown-toggle" type="button" aria-expanded="false" aria-controls="resources-menu">
+            Resources
+            <span class="dropdown-icon" aria-hidden="true"></span>
+          </button>
+          <ul id="resources-menu" class="dropdown-menu" role="menu" hidden>
+            <li role="none"><a role="menuitem" href="faq.html" data-analytics="nav-faq">FAQ</a></li>
+            <li role="none"><a role="menuitem" href="returns.html" data-analytics="nav-returns">Returns</a></li>
+            <li role="none"><a role="menuitem" href="privacy.html" data-analytics="nav-privacy">Privacy</a></li>
+          </ul>
+        </li>
+      </ul>
       <div class="nav-actions">
         <a class="btn nav-cta" href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" data-analytics="nav-shop">Shop eBay</a>
         <a class="nav-link-ghost" href="#contact" data-analytics="nav-contact" data-nav-link>Contact</a>
@@ -94,10 +94,17 @@
       document.documentElement.dataset.navVariant;
     const navbar = document.querySelector('.navbar');
     if (navbar) {
-      if (navVariantAttr === 'classic') {
-        navbar.classList.remove('navbar--compact');
-      } else if (navVariantAttr === 'compact') {
+      const variant =
+        navVariantAttr === 'classic'
+          ? 'floating'
+          : navVariantAttr || navbar.dataset.navVariant || 'floating';
+
+      navbar.classList.remove('navbar--floating', 'navbar--compact');
+
+      if (variant === 'compact') {
         navbar.classList.add('navbar--compact');
+      } else {
+        navbar.classList.add('navbar--floating');
       }
     }
 

--- a/style.css
+++ b/style.css
@@ -240,7 +240,7 @@ h3[id],
 h4[id],
 h5[id],
 h6[id] {
-  scroll-margin-top: calc(var(--navbar-height) + 0.5rem);
+  scroll-margin-top: calc(var(--navbar-height) + 1.25rem);
 }
 p {
   font-size: var(--font-size-base);
@@ -259,7 +259,7 @@ noscript p {
 .policy-page {
   width: min(100%, 1100px);
   margin: 0 auto;
-  padding: calc(var(--navbar-height) + 2.5rem) clamp(1.5rem, 4vw, 3rem) 3rem;
+  padding: calc(var(--navbar-height) + 3.25rem) clamp(1.5rem, 4vw, 3rem) 3rem;
   display: flex;
   flex-direction: column;
   gap: clamp(1.75rem, 4vw, 3rem);
@@ -312,7 +312,7 @@ noscript p {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  scroll-margin-top: calc(var(--navbar-height) + 0.5rem);
+  scroll-margin-top: calc(var(--navbar-height) + 1.25rem);
   align-self: start;
 }
 
@@ -374,7 +374,7 @@ noscript p {
   box-shadow: 0 24px 56px rgba(var(--black-rgb), 0.32);
   transition: border-color 0.25s ease, box-shadow 0.25s ease,
     transform 0.25s ease;
-  scroll-margin-top: calc(var(--navbar-height) + 0.5rem);
+  scroll-margin-top: calc(var(--navbar-height) + 1.25rem);
 }
 
 .policy-accordion details:hover {
@@ -473,13 +473,13 @@ noscript p {
   .policy-toc,
   .toc {
     position: sticky;
-    top: calc(var(--navbar-height) + 2rem);
+    top: calc(var(--navbar-height) + 2.75rem);
   }
 }
 
 @media (max-width: 599px) {
   .policy-page {
-    padding: calc(var(--navbar-height) + 2.25rem) 1rem 2rem;
+    padding: calc(var(--navbar-height) + 3rem) 1rem 2rem;
   }
 
   .policy-hero {
@@ -925,7 +925,7 @@ noscript p {
     color: var(--color-primary);
   }
 .policy-content {
-  padding: calc(var(--navbar-height) + 0.5rem)
+  padding: calc(var(--navbar-height) + 1.25rem)
     calc(env(safe-area-inset-right) + 2rem) 2rem
     calc(env(safe-area-inset-left) + 2rem);
   max-width: 800px;
@@ -989,12 +989,18 @@ noscript p {
   top: 0;
   left: 0;
   width: 100%;
-  padding: calc(env(safe-area-inset-top)+0.7rem)
-    calc(env(safe-area-inset-right)+1.5rem) 0.7rem
-    calc(env(safe-area-inset-left)+1.5rem);
+  box-sizing: border-box;
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 4vw, 2.5rem);
+  justify-content: center;
+  z-index: 10000;
+}
+
+.navbar--floating {
+  padding: calc(env(safe-area-inset-top) + 0.45rem)
+    calc(env(safe-area-inset-right) + 1.25rem) 0.45rem
+    calc(env(safe-area-inset-left) + 1.25rem);
+  gap: clamp(0.75rem, 3.5vw, 1.75rem);
   background: linear-gradient(
       120deg,
       rgba(var(--white-rgb), 0.92),
@@ -1003,16 +1009,28 @@ noscript p {
     border-box;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  z-index: 10000;
-  box-shadow: 0 18px 40px rgba(var(--black-rgb), 0.12);
+  box-shadow: 0 14px 32px rgba(var(--black-rgb), 0.12);
   border-bottom: 1px solid rgba(var(--black-rgb), 0.05);
 }
 
 .navbar__surface {
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 4vw, 2.5rem);
+  gap: clamp(0.75rem, 3vw, 1.75rem);
   width: 100%;
+}
+
+.navbar--floating .navbar__surface,
+[data-nav-variant="floating"] .navbar .navbar__surface,
+[data-nav-variant="classic"] .navbar .navbar__surface {
+  gap: clamp(0.75rem, 3vw, 1.5rem);
+  background: rgba(var(--white-rgb), 0.96);
+  border-radius: 0.65rem;
+  padding: 0.35rem clamp(0.85rem, 2.5vw, 1.5rem);
+  border: 1px solid rgba(var(--black-rgb), 0.04);
+  box-shadow: 0 10px 26px rgba(var(--black-rgb), 0.1);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .navbar__surface .nav-toggle {
@@ -1054,6 +1072,12 @@ noscript p {
   margin-left: 0.25rem;
   transition: transform 0.3s ease;
 }
+.navbar--floating .brand,
+[data-nav-variant="floating"] .navbar .brand,
+[data-nav-variant="classic"] .navbar .brand {
+  gap: 0.6rem;
+  margin-left: 0;
+}
 .brand:hover,
 .brand:focus-visible {
   transform: translateY(-1px);
@@ -1066,6 +1090,11 @@ noscript p {
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
+}
+.navbar--floating .brand-text,
+[data-nav-variant="floating"] .navbar .brand-text,
+[data-nav-variant="classic"] .navbar .brand-text {
+  gap: 0.1rem;
 }
 .navbar--compact .brand-text,
 [data-nav-variant="compact"] .navbar .brand-text {
@@ -1149,6 +1178,12 @@ noscript p {
   align-items: stretch;
   flex: 1 1 auto;
 }
+.navbar--floating .nav-menu,
+[data-nav-variant="floating"] .navbar .nav-menu,
+[data-nav-variant="classic"] .navbar .nav-menu {
+  gap: 1.75rem;
+  padding: 1.25rem;
+}
 .navbar--compact .nav-menu,
 [data-nav-variant="compact"] .navbar .nav-menu {
   gap: 1.5rem;
@@ -1183,8 +1218,13 @@ noscript p {
 .nav-links {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.1rem;
   list-style: none;
+}
+.navbar--floating .nav-links,
+[data-nav-variant="floating"] .navbar .nav-links,
+[data-nav-variant="classic"] .navbar .nav-links {
+  gap: 1.1rem;
 }
 .navbar--compact .nav-links,
 [data-nav-variant="compact"] .navbar .nav-links {
@@ -1193,8 +1233,13 @@ noscript p {
 .nav-actions {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.9rem;
   align-items: stretch;
+}
+.navbar--floating .nav-actions,
+[data-nav-variant="floating"] .navbar .nav-actions,
+[data-nav-variant="classic"] .navbar .nav-actions {
+  gap: 0.85rem;
 }
 .navbar--compact .nav-actions,
 [data-nav-variant="compact"] .navbar .nav-actions {
@@ -1270,6 +1315,12 @@ noscript p {
   background: linear-gradient(120deg, var(--brand-primary), var(--brand-secondary));
   box-shadow: 0 12px 24px rgba(var(--brand-primary-rgb), 0.35);
 }
+.navbar--floating .nav-cta,
+[data-nav-variant="floating"] .navbar .nav-cta,
+[data-nav-variant="classic"] .navbar .nav-cta {
+  padding: 0.65rem 1.45rem;
+  box-shadow: 0 10px 20px rgba(var(--brand-primary-rgb), 0.3);
+}
 .nav-link-ghost {
   display: inline-flex;
   justify-content: center;
@@ -1281,6 +1332,11 @@ noscript p {
   font-weight: 600;
   text-decoration: none;
   transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+.navbar--floating .nav-link-ghost,
+[data-nav-variant="floating"] .navbar .nav-link-ghost,
+[data-nav-variant="classic"] .navbar .nav-link-ghost {
+  padding: 0.65rem 1.45rem;
 }
 .nav-link-ghost:hover,
 .nav-link-ghost:focus-visible {
@@ -1325,26 +1381,47 @@ noscript p {
 }
 @media (min-width: 768px) {
   .nav-menu {
-    gap: 2.5rem;
-    padding: 2rem;
+    gap: 2.1rem;
+    padding: 1.75rem;
+  }
+  .navbar--floating .nav-menu,
+  [data-nav-variant="floating"] .navbar .nav-menu,
+  [data-nav-variant="classic"] .navbar .nav-menu {
+    gap: 1.6rem;
+    padding: 1.5rem;
   }
   .nav-links {
-    gap: 1.5rem;
+    gap: 1.4rem;
+  }
+  .navbar--floating .nav-links,
+  [data-nav-variant="floating"] .navbar .nav-links,
+  [data-nav-variant="classic"] .navbar .nav-links {
+    gap: 1.3rem;
   }
   .nav-actions {
     flex-direction: row;
     align-items: center;
-    gap: 1.25rem;
+    gap: 1.1rem;
+  }
+  .navbar--floating .nav-actions,
+  [data-nav-variant="floating"] .navbar .nav-actions,
+  [data-nav-variant="classic"] .navbar .nav-actions {
+    gap: 0.9rem;
   }
   .nav-link-ghost {
     padding: 0.75rem 1.3rem;
   }
+  .navbar--floating .nav-link-ghost,
+  [data-nav-variant="floating"] .navbar .nav-link-ghost,
+  [data-nav-variant="classic"] .navbar .nav-link-ghost {
+    padding: 0.65rem 1.3rem;
+  }
 }
 @media (min-width: 1024px) {
   .navbar {
-    justify-content: space-between;
-    padding-right: clamp(2rem, 5vw, 4rem);
-    padding-left: clamp(2rem, 5vw, 4rem);
+    justify-content: center;
+    padding-right: 0;
+    padding-left: 0;
   }
   .navbar--compact,
   [data-nav-variant="compact"] .navbar {
@@ -1367,9 +1444,17 @@ noscript p {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    gap: clamp(2rem, 4vw, 3.5rem);
+    flex-wrap: wrap;
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+    row-gap: 0.75rem;
     background: none;
     padding: 0;
+  }
+  .navbar--floating .nav-menu,
+  [data-nav-variant="floating"] .navbar .nav-menu,
+  [data-nav-variant="classic"] .navbar .nav-menu {
+    gap: clamp(1.4rem, 2.5vw, 2.2rem);
+    row-gap: 0.6rem;
   }
   .navbar--compact .nav-menu,
   [data-nav-variant="compact"] .navbar .nav-menu {
@@ -1377,7 +1462,8 @@ noscript p {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: clamp(1.25rem, 3vw, 2.5rem);
+    gap: clamp(1.2rem, 2.75vw, 2.4rem);
+    row-gap: 0.5rem;
   }
   .nav-menu.nav-menu-ready {
     position: static;
@@ -1391,17 +1477,30 @@ noscript p {
   }
   .nav-links {
     flex-direction: row;
-    gap: clamp(1.5rem, 2vw, 2.5rem);
+    flex-wrap: wrap;
+    column-gap: clamp(1.25rem, 2vw, 2.25rem);
+    row-gap: 0.5rem;
+  }
+  .navbar--floating .nav-links,
+  [data-nav-variant="floating"] .navbar .nav-links,
+  [data-nav-variant="classic"] .navbar .nav-links {
+    column-gap: clamp(1.1rem, 2vw, 2rem);
+    row-gap: 0.45rem;
   }
   .navbar--compact .nav-links,
   [data-nav-variant="compact"] .navbar .nav-links {
     flex: 1;
     justify-content: center;
-    gap: clamp(1.1rem, 2.5vw, 2.25rem);
+    column-gap: clamp(1.05rem, 2.5vw, 2.1rem);
   }
   .nav-actions {
     flex-direction: row;
-    gap: 1rem;
+    gap: 0.85rem;
+  }
+  .navbar--floating .nav-actions,
+  [data-nav-variant="floating"] .navbar .nav-actions,
+  [data-nav-variant="classic"] .navbar .nav-actions {
+    gap: 0.75rem;
   }
   .navbar--compact .nav-actions,
   [data-nav-variant="compact"] .navbar .nav-actions {

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -3,43 +3,81 @@ import path from 'path';
 
 test.use({ viewport: { width: 375, height: 667 } });
 
-const filePath = path.resolve(__dirname, '../index.html');
+const variants = [
+  {
+    name: 'floating',
+    expectedClass: 'navbar--floating',
+    file: '../index.html',
+  },
+  {
+    name: 'compact',
+    expectedClass: 'navbar--compact',
+    file: '../faq.html',
+  },
+];
 
-test('menu supports keyboard navigation', async ({ page }) => {
-  await page.addInitScript(() => {
-    document.documentElement.setAttribute('data-nav-variant', 'compact');
-  });
-  await page.goto('file://' + filePath);
+for (const variant of variants) {
+  test(`menu supports keyboard navigation (${variant.name})`, async ({ page }) => {
+    const filePath = path.resolve(__dirname, variant.file);
+    await page.goto('file://' + filePath);
 
-  page.on('console', msg => {
-    if (msg.type() === 'error') {
-      throw new Error(msg.text());
-    }
-  });
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        throw new Error(msg.text());
+      }
+    });
 
-  await page.click('.nav-toggle');
-  await page.locator('.nav-menu.open').waitFor();
+    await expect(page.locator('header.navbar')).toHaveClass(
+      new RegExp(`\\b${variant.expectedClass}\\b`)
+    );
 
-  const focusable = page.locator('.nav-menu a, .nav-menu .dropdown-toggle');
-  const count = await focusable.count();
+    await page.click('.nav-toggle');
+    await page.locator('.nav-menu.open').waitFor();
 
-  await expect(focusable.first()).toBeFocused();
+    const focusable = page.locator('.nav-menu a, .nav-menu .dropdown-toggle');
+    const count = await focusable.count();
 
-  await page.keyboard.press('Tab');
-  await expect(focusable.nth(1)).toBeFocused();
+    await expect(focusable.first()).toBeFocused();
 
-  for (let i = 2; i < count; i++) {
     await page.keyboard.press('Tab');
-    await expect(focusable.nth(i)).toBeFocused();
-  }
+    await expect(focusable.nth(1)).toBeFocused();
 
-  await page.keyboard.press('Tab');
-  await expect(focusable.first()).toBeFocused();
+    for (let i = 2; i < count; i++) {
+      await page.keyboard.press('Tab');
+      await expect(focusable.nth(i)).toBeFocused();
+    }
 
-  await page.keyboard.press('Shift+Tab');
-  await expect(focusable.nth(count - 1)).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(focusable.first()).toBeFocused();
 
-  await page.keyboard.press('Escape');
-  await expect(page.locator('.nav-menu')).not.toHaveClass(/open/);
-  await expect(page.locator('.nav-toggle')).toBeFocused();
+    await page.keyboard.press('Shift+Tab');
+    await expect(focusable.nth(count - 1)).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.nav-menu')).not.toHaveClass(/open/);
+    await expect(page.locator('.nav-toggle')).toBeFocused();
+  });
+}
+
+test.describe('desktop floating navbar', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('floating variant stays within viewport width', async ({ page }) => {
+    const filePath = path.resolve(__dirname, '../index.html');
+    await page.goto('file://' + filePath);
+
+    const header = page.locator('header.navbar');
+    await expect(header).toHaveClass(/\bnavbar--floating\b/);
+
+    const hasOverflow = await page.evaluate(() => {
+      const { scrollWidth, clientWidth } = document.documentElement;
+      return scrollWidth - clientWidth;
+    });
+    expect(Math.abs(hasOverflow)).toBeLessThanOrEqual(1);
+
+    const navLinksWrap = await page.locator('.nav-links').evaluate(el => {
+      return getComputedStyle(el).flexWrap;
+    });
+    expect(navLinksWrap).toBe('wrap');
+  });
 });

--- a/tests/policy-navigation.spec.ts
+++ b/tests/policy-navigation.spec.ts
@@ -17,12 +17,12 @@ test.describe('policy page navigation', () => {
   for (const pageName of pages) {
     test(`${pageName} keeps in-page anchors local`, async ({ page }) => {
       const filePath = path.resolve(__dirname, `../${pageName}`);
-      await page.addInitScript(() => {
-        document.documentElement.setAttribute('data-nav-variant', 'compact');
-      });
       await page.goto('file://' + filePath);
 
       await page.waitForSelector('header.navbar .brand');
+      const header = page.locator('header.navbar');
+      await expect(header).toHaveClass(/\bnavbar--compact\b/);
+      await expect(header).not.toHaveClass(/\bnavbar--floating\b/);
       await page.waitForFunction(() => {
         const brand = document.querySelector<HTMLAnchorElement>('header.navbar .brand');
         return brand?.getAttribute('href')?.startsWith('index.html');

--- a/theme.css
+++ b/theme.css
@@ -30,7 +30,7 @@
   --color-error: #dc2626;
   --color-error-rgb: 220, 38, 38;
 
-  --navbar-height: calc(env(safe-area-inset-top) + 4.5rem);
+  --navbar-height: calc(env(safe-area-inset-top) + 3.75rem);
 
   /* legacy aliases */
   --black: var(--color-text);


### PR DESCRIPTION
## Summary
- restore the floating navbar modifier in the shared partial and inline include script while allowing pages to opt into the compact variant via `data-nav-variant`
- retune floating layout spacing, wrapping, and navbar height tokens so the desktop header stays within the viewport and policy anchors align with the slimmer bar
- mark policy pages as compact in markup, refresh documentation, and update Playwright coverage for both floating and compact scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e67567b268832ca207801da3824fdc