### PR TITLE
Relax scroll snapping and let sections grow with content

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,9 +20,8 @@
 }
 html {
   scroll-behavior: smooth;
-  scroll-snap-type: y mandatory;
 }
-@media (max-width: 640px) {
+@media (pointer: coarse) {
   html {
     scroll-snap-type: y proximity;
   }
@@ -84,7 +83,7 @@ body {
 /* ---------- Sections ---------- */
 section {
   position: relative;
-  min-height: 100dvh;
+  min-height: clamp(520px, 100vh, max-content);
   scroll-snap-align: start;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove mandatory scroll snapping on desktop and only enable snap behavior for coarse pointers
- allow sections to expand naturally by replacing the fixed viewport min-height with a clamp-based floor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6858ff510832c97c6c83dafe9b402