### PR TITLE
Refine typography scale and section hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,11 +171,13 @@
           <div id="package-anim" class="package-anim">
             <img src="logo.png" alt="HecCollects logo representing the collector community" class="logo" width="160" height="160" fetchpriority="high">
           </div>
-            <h1 id="mission">Connecting collectors to trusted finds—and each other</h1>
-            <div class="links">
-              <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn primary-cta cta-glow" data-analytics="ebay" data-share-link>Shop eBay</a>
-              <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn secondary-cta" data-analytics="offerup" data-share-link>Browse OfferUp</a>
-            </div>
+          <p class="heading-eyebrow">Marketplace Hub</p>
+          <h1 id="mission">Connecting collectors to trusted finds—and each other</h1>
+          <p class="heading-subtitle">Curated drops, transparent pricing, and a collector-first experience.</p>
+          <div class="links">
+            <a href="https://ebay.us/m/HoUY1I?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn primary-cta cta-glow" data-analytics="ebay" data-share-link>Shop eBay</a>
+            <a href="https://offerup.co/xluJorjDIVb?utm_source=site&amp;utm_medium=referral" target="_blank" rel="noopener noreferrer" class="btn secondary-cta" data-analytics="offerup" data-share-link>Browse OfferUp</a>
+          </div>
         </div>
         <div class="feature-marquee-container" aria-hidden="true">
           <ul class="feature-marquee" aria-hidden="true">
@@ -198,7 +200,9 @@
       <section id="story">
         <div class="section-content">
           <div class="card reveal">
+            <p class="heading-eyebrow">Meet Hector</p>
             <h2 id="our-story">Our Story</h2>
+            <p class="heading-subtitle">Sharing the passion that fuels every drop.</p>
             <p>Hey! I’m Hector – collector, curator, and all‑around hobby nerd. From childhood nostalgia to investment‑grade assets, I've always looked for the value in products and how they compare within their respective hobbies. I live and breathe trading, but have shifted to selling to maintain my love for learning new hobbies. I price just under market online (with bigger breaks in person) to keep the hobby fun and accessible. Let’s share the passion!</p>
           </div>
         </div>
@@ -226,9 +230,10 @@
       <!-- TESTIMONIALS -->
       <section id="testimonials">
       <div class="section-content">
-        <div class="card reveal">
+        <div class="card card-center reveal">
+          <p class="heading-eyebrow">Testimonials</p>
           <h2>What the People Have Been Saying.</h2>
-          <p>Hear from our customers firsthand.</p>
+          <p class="heading-subtitle">Hear how collectors describe their experience with HecCollects.</p>
           <div class="testimonials" aria-live="polite" data-src="reviews.json">
             <div class="testimonial-track"></div>
             <div class="testimonial-controls">

--- a/style.css
+++ b/style.css
@@ -2,13 +2,24 @@
 /* Color variables are defined in theme.css */
 :root {
   --font-family-base: "Poppins", sans-serif;
-  --font-size-base: 1rem;
-  --font-size-h1: 2.5rem;
-  --font-size-h2: 1.75rem;
-  --font-size-h3: 1.25rem;
+  --font-size-base: clamp(1rem, 0.28vw + 0.95rem, 1.125rem);
+  --font-size-sm: clamp(0.85rem, 0.25vw + 0.8rem, 0.975rem);
+  --font-size-lg: clamp(1.125rem, 0.35vw + 1rem, 1.35rem);
+  --font-size-xl: clamp(1.35rem, 0.65vw + 1.1rem, 1.75rem);
+  --font-size-h1: clamp(2.5rem, 4vw + 1.5rem, 4rem);
+  --font-size-h2: clamp(1.85rem, 3vw + 1.2rem, 3rem);
+  --font-size-h3: clamp(1.35rem, 2vw + 1rem, 2.1rem);
+  --heading-letter-spacing: -0.015em;
+  --display-letter-spacing: -0.02em;
+  --eyebrow-size: clamp(0.68rem, 0.18vw + 0.62rem, 0.8rem);
+  --eyebrow-letter-spacing: 0.32em;
+  --subtitle-size: clamp(1.05rem, 0.45vw + 0.95rem, 1.35rem);
+  --subtitle-letter-spacing: 0.02em;
+  --heading-gap: clamp(0.85rem, 1.6vw, 2.25rem);
+  --heading-stack-gap: clamp(0.5rem, 1vw, 1.2rem);
   --line-height-base: 1.6;
-  --line-height-heading: 1.3;
-  --content-gap: 1.5rem;
+  --line-height-heading: 1.25;
+  --content-gap: clamp(1.25rem, 1.25vw + 1rem, 2rem);
 }
 /* ---------- Reset & Base ---------- */
 *,
@@ -98,7 +109,7 @@ section::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(var(--black-rgb), 0.7);
+  background: rgba(var(--black-rgb), 0.35);
   z-index: 0;
 }
 
@@ -107,7 +118,30 @@ section + section {
 }
 
 section:nth-of-type(even)::after {
-  background: rgba(var(--black-rgb), 0.6);
+  background: rgba(var(--black-rgb), 0.28);
+}
+#home::after {
+  background: linear-gradient(
+    180deg,
+    rgba(var(--black-rgb), 0.1) 0%,
+    rgba(var(--black-rgb), 0.22) 42%,
+    rgba(var(--black-rgb), 0.38) 100%
+  );
+}
+#story::after {
+  background: linear-gradient(
+    160deg,
+    rgba(var(--brand-primary-rgb), 0.18) 0%,
+    rgba(var(--black-rgb), 0.42) 85%
+  );
+}
+#testimonials::after {
+  background: linear-gradient(
+    140deg,
+    rgba(var(--black-rgb), 0.3) 0%,
+    rgba(var(--brand-secondary-rgb), 0.35) 60%,
+    rgba(var(--black-rgb), 0.45) 100%
+  );
 }
 .section-content {
   position: relative;
@@ -133,24 +167,87 @@ section:nth-of-type(even)::after {
 }
 /* ---------- Card ---------- */
 .card {
-  background: rgba(var(--white-rgb), 0.15);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 2px solid rgba(var(--white-rgb), 0.25);
+  position: relative;
+  background: linear-gradient(
+    155deg,
+    rgba(var(--white-rgb), 0.2) 0%,
+    rgba(var(--white-rgb), 0.08) 100%
+  );
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(var(--white-rgb), 0.28);
   border-radius: 1.6rem;
-  padding: 2rem;
+  padding: clamp(1.75rem, 2vw + 1.25rem, 2.5rem);
   width: 100%;
-  max-width: 460px;
-  box-shadow: 0 25px 50px rgba(var(--black-rgb), 0.35);
-  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+  max-width: 520px;
+  box-shadow:
+    0 22px 48px rgba(var(--black-rgb), 0.28),
+    0 0 0 1px rgba(var(--white-rgb), 0.08) inset;
+  transition:
+    transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.35s ease,
+    border-color 0.35s ease;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: var(--content-gap);
   text-align: left;
+  overflow: hidden;
+}
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(var(--brand-primary-rgb), 0.6), rgba(var(--color-accent-rgb), 0.5));
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0.35;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+.card.card-center {
+  align-items: center;
+  text-align: center;
 }
 .card p {
   margin-bottom: 0;
+}
+
+#home .card h1 {
+  max-width: clamp(22ch, 60vw, 34ch);
+}
+#home .card .heading-subtitle {
+  color: rgba(var(--color-text-rgb), 0.7);
+}
+#home .heading-eyebrow {
+  color: rgba(var(--color-text-rgb), 0.75);
+}
+
+#story .card {
+  max-width: 640px;
+}
+#story .card .heading-subtitle {
+  color: rgba(var(--color-text-rgb), 0.68);
+}
+
+#testimonials .card {
+  max-width: 720px;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+}
+#testimonials h2::after {
+  background: linear-gradient(120deg, var(--color-accent), var(--brand-primary));
+}
+#testimonials .heading-subtitle {
+  color: rgba(var(--color-text-rgb), 0.75);
 }
 
 .card-center {
@@ -158,7 +255,13 @@ section:nth-of-type(even)::after {
   text-align: center;
 }
 .card:hover {
-  transform: translateY(-10px) rotateX(5deg) rotateY(-5deg);
+  transform: translateY(-10px) rotateX(4deg) rotateY(-4deg);
+  box-shadow:
+    0 32px 64px rgba(var(--black-rgb), 0.32),
+    0 0 0 1px rgba(var(--white-rgb), 0.12) inset;
+}
+.card:hover::before {
+  opacity: 0.55;
 }
 .tilt:hover {
   transform: none;
@@ -215,23 +318,42 @@ section:nth-of-type(even)::after {
 h1,
 h2,
 h3 {
-  margin-bottom: var(--content-gap);
+  margin-bottom: var(--heading-stack-gap);
   line-height: var(--line-height-heading);
+  letter-spacing: var(--heading-letter-spacing);
 }
 h1 {
   font-size: var(--font-size-h1);
-  font-weight: 700;
-  text-shadow: 0 3px 8px rgba(var(--black-rgb), 0.4);
+  font-weight: 800;
+  letter-spacing: var(--display-letter-spacing);
+  color: var(--color-text);
+  text-shadow:
+    0 12px 32px rgba(var(--brand-primary-rgb), 0.35),
+    0 4px 12px rgba(var(--black-rgb), 0.45);
 }
 h2 {
   font-size: var(--font-size-h2);
   font-weight: 700;
-  color: var(--color-primary);
+  color: var(--color-text);
+  letter-spacing: calc(var(--heading-letter-spacing) / 2);
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(0.35rem, 0.6vw, 0.6rem);
+}
+h2::after {
+  content: "";
+  display: block;
+  width: clamp(2.5rem, 14vw, 6rem);
+  height: 3px;
+  background: linear-gradient(120deg, var(--brand-primary), var(--color-accent));
+  border-radius: 999px;
 }
 h3 {
   font-size: var(--font-size-h3);
   font-weight: 600;
-  color: var(--color-primary);
+  color: rgba(var(--color-text-rgb), 0.85);
 }
 h1[id],
 h2[id],
@@ -246,6 +368,67 @@ p {
   line-height: var(--line-height-base);
   max-width: 680px;
   margin-bottom: var(--content-gap);
+}
+.heading-eyebrow {
+  font-size: var(--eyebrow-size);
+  font-weight: 600;
+  letter-spacing: var(--eyebrow-letter-spacing);
+  text-transform: uppercase;
+  color: rgba(var(--color-text-rgb), 0.68);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: clamp(0.4rem, 0.8vw, 0.75rem);
+}
+.heading-eyebrow::before,
+.heading-eyebrow::after {
+  content: "";
+  display: inline-block;
+  width: clamp(1.5rem, 8vw, 2.5rem);
+  height: 1px;
+  background: linear-gradient(120deg, rgba(var(--brand-primary-rgb), 0.6), rgba(var(--color-accent-rgb), 0.45));
+  border-radius: 999px;
+}
+.heading-eyebrow::after {
+  display: none;
+}
+.card .heading-eyebrow::before {
+  display: inline-block;
+}
+.card .heading-eyebrow {
+  justify-content: flex-start;
+  margin-bottom: clamp(0.45rem, 1vw, 0.85rem);
+}
+.card.card-center .heading-eyebrow {
+  justify-content: center;
+}
+.card.card-center .heading-eyebrow::before {
+  display: inline-block;
+}
+.card.card-center .heading-eyebrow::after {
+  display: inline-block;
+}
+.card.card-center h2 {
+  align-items: center;
+  text-align: center;
+}
+.card.card-center h2::after {
+  margin-inline: auto;
+}
+.heading-subtitle {
+  font-size: var(--subtitle-size);
+  letter-spacing: var(--subtitle-letter-spacing);
+  color: rgba(var(--color-text-rgb), 0.8);
+  margin-bottom: var(--heading-gap);
+  max-width: clamp(30ch, 60vw, 48ch);
+}
+.card .heading-subtitle {
+  color: rgba(var(--color-text-rgb), 0.72);
+  margin-bottom: var(--heading-gap);
+}
+.card.card-center .heading-subtitle {
+  text-align: center;
 }
 noscript p {
   margin: 1rem;


### PR DESCRIPTION
## Summary
- replace the base font sizing tokens with clamp-driven scales and add dedicated variables for eyebrows, subtitles, and heading spacing
- restyle headings, eyebrow labels, subtitles, and hero/testimonial/story cards to create a clearer typographic ladder
- soften section overlays and refresh card borders/shadows to let gradients and hierarchy stand out

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68d95eb20832c99cef849be0206fc