### PR TITLE
Fix desktop resources dropdown visibility and keyboard flow

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -21,7 +21,7 @@
             Resources
             <span class="dropdown-icon" aria-hidden="true"></span>
           </button>
-          <ul id="resources-menu" class="dropdown-menu" role="menu" hidden>
+          <ul id="resources-menu" class="dropdown-menu" role="menu">
             <li role="none"><a role="menuitem" href="faq.html" data-analytics="nav-faq">FAQ</a></li>
             <li role="none"><a role="menuitem" href="returns.html" data-analytics="nav-returns">Returns</a></li>
             <li role="none"><a role="menuitem" href="privacy.html" data-analytics="nav-privacy">Privacy</a></li>

--- a/scripts/includes.js
+++ b/scripts/includes.js
@@ -26,7 +26,7 @@
             Resources
             <span class="dropdown-icon" aria-hidden="true"></span>
           </button>
-          <ul id="resources-menu" class="dropdown-menu" role="menu" hidden>
+          <ul id="resources-menu" class="dropdown-menu" role="menu">
             <li role="none"><a role="menuitem" href="faq.html" data-analytics="nav-faq">FAQ</a></li>
             <li role="none"><a role="menuitem" href="returns.html" data-analytics="nav-returns">Returns</a></li>
             <li role="none"><a role="menuitem" href="privacy.html" data-analytics="nav-privacy">Privacy</a></li>

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -56,6 +56,22 @@
     burger.setAttribute('aria-expanded', 'false');
     navMenu.setAttribute('aria-hidden', 'true');
 
+    const isDesktop = () => mql.matches;
+
+    const setMenuVisibility = (menu, isOpen) => {
+      if (!menu) return;
+      menu.classList.toggle('dropdown-menu--open', isOpen);
+      if (isDesktop()) {
+        menu.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+      } else {
+        menu.removeAttribute('aria-hidden');
+      }
+    };
+
+    const hideMenu = (menu) => setMenuVisibility(menu, false);
+
+    const showMenu = (menu) => setMenuVisibility(menu, true);
+
     const closeDropdowns = (exception) => {
       dropdownToggles.forEach(toggle => {
         if (exception && toggle === exception) return;
@@ -63,34 +79,41 @@
         const menuId = toggle.getAttribute('aria-controls');
         if (!menuId) return;
         const menu = document.getElementById(menuId);
-        if (menu && !menu.hasAttribute('hidden')) {
-          menu.setAttribute('hidden', '');
-        }
+        hideMenu(menu);
       });
     };
 
     dropdownToggles.forEach(toggle => {
       const menuId = toggle.getAttribute('aria-controls');
       const menu = menuId ? document.getElementById(menuId) : null;
-      if (menu && !menu.hasAttribute('hidden')) {
-        menu.setAttribute('hidden', '');
-      }
+      hideMenu(menu);
       toggle.addEventListener('click', (event) => {
         event.stopPropagation();
         const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
         if (isExpanded) {
           toggle.setAttribute('aria-expanded', 'false');
-          menu?.setAttribute('hidden', '');
+          hideMenu(menu);
         } else {
           closeDropdowns(toggle);
           toggle.setAttribute('aria-expanded', 'true');
-          menu?.removeAttribute('hidden');
+          showMenu(menu);
         }
       });
       toggle.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
+        if (event.key === 'Tab' && !event.shiftKey) {
+          closeDropdowns(toggle);
+          toggle.setAttribute('aria-expanded', 'true');
+          showMenu(menu);
+        } else if (event.key === 'Escape') {
           closeDropdowns();
           toggle.blur();
+        }
+      });
+      menu?.addEventListener('focusout', (event) => {
+        const next = event.relatedTarget;
+        if (!next || (!menu.contains(next) && next !== toggle)) {
+          toggle.setAttribute('aria-expanded', 'false');
+          hideMenu(menu);
         }
       });
     });

--- a/style.css
+++ b/style.css
@@ -1982,6 +1982,10 @@ noscript p {
     border-left: none;
     min-width: 13rem;
     z-index: 10002;
+    display: none;
+  }
+  .dropdown-menu.dropdown-menu--open {
+    display: flex;
   }
   .nav-item {
     position: relative;


### PR DESCRIPTION
## Summary
- replace the navbar resources menu hidden attribute with logic that toggles a new `dropdown-menu--open` class
- update the dropdown script to set aria-hidden on desktop, support keyboard tabbing, and close when focus leaves the menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6906bd9948d4832cb8107c00cfca4cce